### PR TITLE
fix: adjust heading margin-top values for better spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.2.1] - 2026-01-24
+
+### Fixed
+
+* Fixed heading margin-top values for better visual spacing (h1:24px, h2:20px, h3:16px, h4:12px, h5:8px, h6:8px)
+
 ## \[1.2.0] - 2026-01-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "Milkdown Markdown WYSIWYG",
   "description": "A beautiful WYSIWYG Markdown editor powered by Milkdown Crepe. Edit markdown files with rich text experience and theme selection.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -244,6 +244,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             --heading-h4-size: 20px;
             --heading-h5-size: 18px;
             --heading-h6-size: 16px;
+            --heading-h1-margin: 24px;
+            --heading-h2-margin: 20px;
+            --heading-h3-margin: 16px;
+            --heading-h4-margin: 12px;
+            --heading-h5-margin: 8px;
+            --heading-h6-margin: 8px;
             /* Default Milkdown theme variables (dark) - prevents flash */
             --crepe-color-background: var(--vscode-editor-background, #1e1e1e);
             --crepe-color-on-background: var(--vscode-editor-foreground, #d4d4d4);
@@ -294,12 +300,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             line-height: calc(24px * var(--editor-font-scale, 1)) !important;
           }
           /* Heading font sizes */
-          .milkdown .ProseMirror h1 { font-size: var(--heading-h1-size, 32px) !important; }
-          .milkdown .ProseMirror h2 { font-size: var(--heading-h2-size, 28px) !important; }
-          .milkdown .ProseMirror h3 { font-size: var(--heading-h3-size, 24px) !important; }
-          .milkdown .ProseMirror h4 { font-size: var(--heading-h4-size, 20px) !important; }
-          .milkdown .ProseMirror h5 { font-size: var(--heading-h5-size, 18px) !important; }
-          .milkdown .ProseMirror h6 { font-size: var(--heading-h6-size, 16px) !important; }
+          .milkdown .ProseMirror h1 { font-size: var(--heading-h1-size, 32px) !important; margin-top: var(--heading-h1-margin, 24px) !important; }
+          .milkdown .ProseMirror h2 { font-size: var(--heading-h2-size, 28px) !important; margin-top: var(--heading-h2-margin, 20px) !important; }
+          .milkdown .ProseMirror h3 { font-size: var(--heading-h3-size, 24px) !important; margin-top: var(--heading-h3-margin, 16px) !important; }
+          .milkdown .ProseMirror h4 { font-size: var(--heading-h4-size, 20px) !important; margin-top: var(--heading-h4-margin, 12px) !important; }
+          .milkdown .ProseMirror h5 { font-size: var(--heading-h5-size, 18px) !important; margin-top: var(--heading-h5-margin, 8px) !important; }
+          .milkdown .ProseMirror h6 { font-size: var(--heading-h6-size, 16px) !important; margin-top: var(--heading-h6-margin, 8px) !important; }
 
           #toolbar {
             display: flex;


### PR DESCRIPTION
## Summary
- Fixed heading margin-top values for better visual spacing
- h1: 24px, h2: 20px, h3: 16px, h4: 12px, h5: 8px, h6: 8px

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Open .md file and verify heading spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heading margin spacing (h1–h6) to improve visual consistency in the markdown editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->