### PR TITLE
feat: add collapsible metadata panel for YAML frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
 ### Added
 
+* Cursor line highlight with theme support
+  * Highlights current block/paragraph containing cursor
+  * Individual list item highlighting (not entire list)
+  * Skips code blocks (they have built-in highlighting)
+  * Configurable via `tuiMarkdown.highlightCurrentLine` setting
+
+* Responsive max-width layout (1200px) for editor content on large screens
+  * Improves readability on 4K/ultrawide monitors
+  * Full-width on screens ≤1200px (split view compatible)
+
 * Collapsible metadata panel for editing YAML frontmatter
 
 * YAML validation with line number error display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 * YAML validation with line number error display
 * "Add Metadata" button when document has no frontmatter
 * Bidirectional sync between metadata panel and Milkdown editor
+* Tab key support in metadata textarea (inserts 2 spaces for YAML indentation)
 * `gray-matter` and `js-yaml` dependencies for frontmatter parsing and validation
 
 ## \[1.2.1] - 2026-01-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Added
 
 * Collapsible metadata panel for editing YAML frontmatter
+
 * YAML validation with line number error display
+
 * "Add Metadata" button when document has no frontmatter
+
 * Bidirectional sync between metadata panel and Milkdown editor
+
 * Tab key support in metadata textarea (inserts 2 spaces for YAML indentation)
-* `gray-matter` and `js-yaml` dependencies for frontmatter parsing and validation
+
+* `js-yaml` dependency for frontmatter parsing and validation
 
 ## \[1.2.1] - 2026-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.3.0] - 2026-01-24
+
+### Added
+
+* Collapsible metadata panel for editing YAML frontmatter
+* YAML validation with line number error display
+* "Add Metadata" button when document has no frontmatter
+* Bidirectional sync between metadata panel and Milkdown editor
+* `gray-matter` and `js-yaml` dependencies for frontmatter parsing and validation
+
 ## \[1.2.1] - 2026-01-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,15 @@ src/
 ├── utils/getNonce.ts         # CSP nonce generator
 └── webview/
     ├── main.ts               # Browser-side Milkdown Crepe editor
-    └── frontmatter.ts        # YAML parsing & validation utilities
+    ├── frontmatter.ts        # YAML parsing & validation utilities
+    └── line-highlight-plugin.ts # ProseMirror plugin for cursor line highlight
 ```
 
 ## Configuration Settings
 
 Extension provides these settings via `tuiMarkdown.*` namespace:
 - Font size (8-32px), heading sizes H1-H6 (12-72px)
+- `highlightCurrentLine` (boolean, default: true) - Enable cursor line highlight
 
 ## Milkdown Crepe Integration
 
@@ -84,3 +86,16 @@ Uses `@milkdown/crepe` package. Theme variables are manually applied via CSS cus
 4. Empty metadata → Remove frontmatter delimiters from document
 
 **Dependencies**: `js-yaml@^4.1.1`, `@types/js-yaml` (dev)
+
+## Line Highlight
+
+**Plugin** (`src/webview/line-highlight-plugin.ts`):
+- ProseMirror plugin using Decoration API
+- Highlights immediate block containing cursor (paragraph, heading, list item)
+- Skips code blocks (they have built-in line highlighting from CodeMirror)
+- Injected via `prosePluginsCtx` before Crepe instance creation
+
+**CSS** (in `src/markdownEditorProvider.ts`):
+- Uses `::before` pseudo-element with `z-index: -1` stacking
+- Light themes: `rgba(0, 0, 0, 0.08)` background
+- Dark themes (`theme-frame-dark`, `theme-nord-dark`): `rgba(255, 255, 255, 0.08)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ npm run package    # Package extension as .vsix
 src/
 ├── extension.ts              # Entry point, registers MarkdownEditorProvider
 ├── markdownEditorProvider.ts # CustomTextEditorProvider + HTML/CSS template
+├── constants.ts              # Shared constants (MAX_FILE_SIZE)
 ├── utils/getNonce.ts         # CSP nonce generator
 └── webview/
     ├── main.ts               # Browser-side Milkdown Crepe editor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Uses `@milkdown/crepe` package. Theme variables are manually applied via CSS cus
 **Panel UI** (integrated in `src/markdownEditorProvider.ts` HTML):
 - Collapsible `<details>` element styled with VSCode theme variables
 - Textarea for YAML editing with syntax error display (red border + error message)
+- Tab key inserts 2 spaces (YAML standard indentation)
 - "Add Metadata" button when no frontmatter exists
 - Panel integrates seamlessly below toolbar, above editor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ Uses `@milkdown/crepe` package. Theme variables are manually applied via CSS cus
 ## Metadata Panel
 
 **Frontmatter Handling** (`src/webview/frontmatter.ts`):
-- Parses YAML frontmatter using `gray-matter` library
-- Validates YAML syntax with `js-yaml`, returns error with line numbers
+- Parses and validates YAML frontmatter using `js-yaml` library
+- Returns validation errors with line numbers
 - Reconstructs markdown with frontmatter delimiters (`---`)
 - Handles edge cases: empty frontmatter, missing delimiters, invalid YAML
 
@@ -83,4 +83,4 @@ Uses `@milkdown/crepe` package. Theme variables are manually applied via CSS cus
 3. External document change → Reparse → Refresh metadata display
 4. Empty metadata → Remove frontmatter delimiters from document
 
-**Dependencies**: `gray-matter@^4.0.3`, `@types/js-yaml` (dev)
+**Dependencies**: `js-yaml@^4.1.1`, `@types/js-yaml` (dev)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 ## Features
 
 - **Rich Text Editing**: Edit markdown with a WYSIWYG interface
-- **Theme Selection**: Choose from multiple editor themes (Nord, GitHub, Tokyo Night, etc.)
+- **Theme Selection**: Choose from multiple editor themes (Frame, Nord, etc.)
 - **View Source**: Toggle between WYSIWYG and source view
+- **Cursor Line Highlight**: Visual highlight of current block/paragraph
+- **Metadata Panel**: Collapsible YAML frontmatter editor with validation
 - **Large File Warning**: Protection for files >500KB
 - **Configurable Font Size**: Adjust editor font size (8-32px)
 - **Configurable Heading Sizes**: Customize font sizes for H1-H6 headings (12-72px)
@@ -23,6 +25,7 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `tuiMarkdown.fontSize` | 16 | Editor font size (8-32px) |
+| `tuiMarkdown.highlightCurrentLine` | true | Enable cursor line highlight |
 | `tuiMarkdown.headingSizes.h1` | 32 | H1 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h2` | 28 | H2 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h3` | 24 | H3 heading font size (12-72px) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "gray-matter": "^4.0.3"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.0.10",
         "@types/vscode": "^1.85.0",
         "esbuild": "^0.20.0",
@@ -1930,6 +1931,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/katex": {
       "version": "0.16.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@milkdown/crepe": "^7.18.0",
-        "gray-matter": "^4.0.3"
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -2106,13 +2106,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -2323,19 +2320,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2347,42 +2331,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -2397,13 +2345,12 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2423,15 +2370,6 @@
       },
       "bin": {
         "katex": "cli.js"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/lodash-es": {
@@ -3650,19 +3588,6 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3726,21 +3651,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/crepe": "^7.18.0"
+        "@milkdown/crepe": "^7.18.0",
+        "gray-matter": "^4.0.3"
       },
       "devDependencies": {
         "@types/node": "^25.0.10",
@@ -2096,6 +2097,15 @@
       "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2305,6 +2315,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2317,6 +2340,42 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -2327,6 +2386,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/katex": {
@@ -2343,6 +2415,15 @@
       },
       "bin": {
         "katex": "cli.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lodash-es": {
@@ -3561,6 +3642,19 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3624,6 +3718,21 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
           "minimum": 12,
           "maximum": 72,
           "description": "Font size for H6 headings (in pixels)"
+        },
+        "tuiMarkdown.highlightCurrentLine": {
+          "type": "boolean",
+          "default": true,
+          "description": "Highlight the line containing the cursor in the editor"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "Milkdown Markdown WYSIWYG",
   "description": "A beautiful WYSIWYG Markdown editor powered by Milkdown Crepe. Edit markdown files with rich text experience and theme selection.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,6 @@
   },
   "dependencies": {
     "@milkdown/crepe": "^7.18.0",
-    "gray-matter": "^4.0.3"
+    "js-yaml": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
-    "@milkdown/crepe": "^7.18.0"
+    "@milkdown/crepe": "^7.18.0",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "package": "vsce package"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.0.10",
     "@types/vscode": "^1.85.0",
     "esbuild": "^0.20.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+// Shared constants between extension and webview
+
+// Maximum file size allowed for the editor (500KB)
+// Used in markdownEditorProvider.ts for file size warning
+// Used in frontmatter.ts for regex operation guard
+export const MAX_FILE_SIZE = 500 * 1024;

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -381,6 +381,83 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             to { transform: rotate(360deg); }
           }
 
+          /* Metadata Panel */
+          #metadata-panel {
+            border-bottom: 1px solid var(--vscode-panel-border);
+            background: var(--vscode-editor-background);
+          }
+          #metadata-details { margin: 0; }
+          #metadata-summary {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            cursor: pointer;
+            user-select: none;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--vscode-editor-foreground);
+            background: var(--vscode-editor-background);
+          }
+          #metadata-summary:hover {
+            background: var(--vscode-list-hoverBackground);
+          }
+          #metadata-summary:focus {
+            outline: 2px solid var(--vscode-focusBorder);
+            outline-offset: -2px;
+          }
+          .toggle-icon::before {
+            content: '▼';
+            font-size: 10px;
+            transition: transform 0.15s ease;
+          }
+          #metadata-details:not([open]) .toggle-icon::before {
+            transform: rotate(-90deg);
+          }
+          .error-indicator {
+            color: var(--vscode-errorForeground);
+            font-size: 11px;
+          }
+          .error-indicator.hidden { display: none; }
+          .metadata-content { padding: 0 12px 12px; }
+          #metadata-textarea {
+            width: 100%;
+            min-height: 80px;
+            max-height: 300px;
+            padding: 8px;
+            font-family: var(--vscode-editor-font-family, monospace);
+            font-size: 13px;
+            line-height: 1.4;
+            color: var(--vscode-input-foreground);
+            background: var(--vscode-input-background);
+            border: 1px solid var(--vscode-input-border);
+            border-radius: 4px;
+            resize: vertical;
+            overflow-y: auto;
+          }
+          #metadata-textarea:focus {
+            outline: none;
+            border-color: var(--vscode-focusBorder);
+          }
+          #add-metadata-btn {
+            display: block;
+            width: calc(100% - 24px);
+            margin: 8px 12px;
+            padding: 8px 12px;
+            font-size: 12px;
+            color: var(--vscode-button-secondaryForeground);
+            background: var(--vscode-button-secondaryBackground);
+            border: 1px dashed var(--vscode-input-border);
+            border-radius: 4px;
+            cursor: pointer;
+            text-align: center;
+          }
+          #add-metadata-btn:hover {
+            background: var(--vscode-list-hoverBackground);
+          }
+          #add-metadata-btn.hidden { display: none; }
+          #metadata-details.hidden { display: none; }
+
         </style>
       </head>
       <body style="background: var(--vscode-editor-background, #1e1e1e);">
@@ -392,6 +469,25 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             <option value="nord-dark">Nord Dark</option>
           </select>
           <button id="btn-source" class="view-source-btn" aria-label="View source in text editor">View Source</button>
+        </div>
+        <div id="metadata-panel">
+          <details id="metadata-details" class="hidden" open>
+            <summary id="metadata-summary">
+              <span class="toggle-icon"></span>
+              <span class="panel-label">Metadata</span>
+              <span id="metadata-error" class="error-indicator hidden"></span>
+            </summary>
+            <div class="metadata-content">
+              <textarea
+                id="metadata-textarea"
+                spellcheck="false"
+                placeholder="key: value"
+                aria-label="YAML frontmatter"></textarea>
+            </div>
+          </details>
+          <button id="add-metadata-btn" class="hidden" aria-label="Add metadata">
+            + Add Metadata
+          </button>
         </div>
         <div id="editor-container">
           <div id="loading-indicator">

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -439,6 +439,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             outline: none;
             border-color: var(--vscode-focusBorder);
           }
+          #metadata-textarea.error {
+            border-color: var(--vscode-inputValidation-errorBorder, #be1100);
+          }
           #add-metadata-btn {
             display: block;
             width: calc(100% - 24px);

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -269,6 +269,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             --crepe-color-secondary: #404040;
             --crepe-color-on-secondary: #ffffff;
             --crepe-color-selected: #4a4a4a;
+            --content-max-width: 1200px;
           }
           * { box-sizing: border-box; }
           html, body {
@@ -316,20 +317,25 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .milkdown .ProseMirror h6 { font-size: var(--heading-h6-size, 16px) !important; margin-top: var(--heading-h6-margin, 8px) !important; }
 
           /* Line highlight for current cursor position */
-          .milkdown .ProseMirror .line-highlight { position: relative; }
+          .milkdown .ProseMirror .line-highlight {
+            position: relative;
+            z-index: 0; /* Create stacking context so ::before z-index:-1 stays above parent bg */
+          }
           .milkdown .ProseMirror .line-highlight::before {
             content: '';
             position: absolute;
             top: 0;
             bottom: 0;
-            left: -9999px;
-            right: -9999px;
-            background: rgba(0, 0, 0, 0.04);
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.08);
             pointer-events: none;
             z-index: -1;
           }
-          body.dark-theme .milkdown .ProseMirror .line-highlight::before {
-            background: rgba(255, 255, 255, 0.04);
+          /* Dark themes override */
+          body.theme-frame-dark .milkdown .ProseMirror .line-highlight::before,
+          body.theme-nord-dark .milkdown .ProseMirror .line-highlight::before {
+            background: rgba(255, 255, 255, 0.08);
           }
 
           #toolbar {
@@ -487,6 +493,16 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
           #add-metadata-btn.hidden { display: none; }
           #metadata-details.hidden { display: none; }
+
+          /* Responsive editor content for large screens */
+          .milkdown .ProseMirror {
+            max-width: var(--content-max-width, 1200px);
+            margin-left: auto;
+            margin-right: auto;
+          }
+          @media (max-width: 1200px) {
+            .milkdown .ProseMirror { max-width: 100%; }
+          }
 
         </style>
       </head>

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -479,7 +479,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             <summary id="metadata-summary">
               <span class="toggle-icon"></span>
               <span class="panel-label">Metadata</span>
-              <span id="metadata-error" class="error-indicator hidden"></span>
+              <span id="metadata-error" class="error-indicator hidden" role="status" aria-live="polite"></span>
             </summary>
             <div class="metadata-content">
               <textarea

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -408,6 +408,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
           .toggle-icon::before {
             content: '▼';
+            display: inline-block;
             font-size: 10px;
             transition: transform 0.15s ease;
           }

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { MAX_FILE_SIZE } from "./constants";
 import { getNonce } from "./utils/getNonce";
 
 /**
@@ -15,7 +16,6 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel: vscode.WebviewPanel,
     _token: vscode.CancellationToken,
   ): Promise<void> {
-    const MAX_FILE_SIZE = 500 * 1024;
     const fileSize = Buffer.byteLength(document.getText(), "utf8");
 
     if (fileSize > MAX_FILE_SIZE) {

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -275,6 +275,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
           .milkdown .ProseMirror {
             padding: 10px 40px;
+            caret-color: var(--crepe-color-caret, var(--crepe-color-primary));
           }
           /* Override body text font size only (headings unchanged) */
           .milkdown .ProseMirror p,
@@ -475,7 +476,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           <button id="btn-source" class="view-source-btn" aria-label="View source in text editor">View Source</button>
         </div>
         <div id="metadata-panel">
-          <details id="metadata-details" class="hidden" open>
+          <details id="metadata-details" class="hidden">
             <summary id="metadata-summary">
               <span class="toggle-icon"></span>
               <span class="panel-label">Metadata</span>

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -87,11 +87,17 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       };
     };
 
+    const getHighlightCurrentLine = (): boolean => {
+      const config = vscode.workspace.getConfiguration("tuiMarkdown");
+      return config.get<boolean>("highlightCurrentLine", true);
+    };
+
     const sendConfig = () => {
       webviewPanel.webview.postMessage({
         type: "config",
         fontSize: getFontSize(),
         headingSizes: getHeadingSizes(),
+        highlightCurrentLine: getHighlightCurrentLine(),
       });
     };
 
@@ -183,7 +189,8 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       vscode.workspace.onDidChangeConfiguration((e) => {
         if (
           e.affectsConfiguration("tuiMarkdown.fontSize") ||
-          e.affectsConfiguration("tuiMarkdown.headingSizes")
+          e.affectsConfiguration("tuiMarkdown.headingSizes") ||
+          e.affectsConfiguration("tuiMarkdown.highlightCurrentLine")
         ) {
           sendConfig();
         }
@@ -274,7 +281,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             color: var(--vscode-editor-foreground, #d4d4d4);
           }
           .milkdown .ProseMirror {
-            padding: 10px 40px;
+            padding: 10px 40px 100px 40px;
             caret-color: var(--crepe-color-caret, var(--crepe-color-primary));
           }
           /* Override body text font size only (headings unchanged) */
@@ -307,6 +314,23 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .milkdown .ProseMirror h4 { font-size: var(--heading-h4-size, 20px) !important; margin-top: var(--heading-h4-margin, 12px) !important; }
           .milkdown .ProseMirror h5 { font-size: var(--heading-h5-size, 18px) !important; margin-top: var(--heading-h5-margin, 8px) !important; }
           .milkdown .ProseMirror h6 { font-size: var(--heading-h6-size, 16px) !important; margin-top: var(--heading-h6-margin, 8px) !important; }
+
+          /* Line highlight for current cursor position */
+          .milkdown .ProseMirror .line-highlight { position: relative; }
+          .milkdown .ProseMirror .line-highlight::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: -9999px;
+            right: -9999px;
+            background: rgba(0, 0, 0, 0.04);
+            pointer-events: none;
+            z-index: -1;
+          }
+          body.dark-theme .milkdown .ProseMirror .line-highlight::before {
+            background: rgba(255, 255, 255, 0.04);
+          }
 
           #toolbar {
             display: flex;
@@ -344,7 +368,8 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
           #editor-container {
             height: calc(100vh - 40px);
-            overflow: auto;
+            overflow-x: hidden;
+            overflow-y: auto;
             position: relative;
           }
           #editor { width: 100%; min-height: 100%; }

--- a/src/webview/frontmatter.ts
+++ b/src/webview/frontmatter.ts
@@ -1,4 +1,5 @@
 import yaml from "js-yaml";
+import { MAX_FILE_SIZE } from "../constants";
 
 export interface ParsedContent {
   frontmatter: string | null;
@@ -11,8 +12,6 @@ export interface ParsedContent {
 const FRONTMATTER_REGEX = /^---[ \t]*\n([\s\S]*?)\n---[ \t]*(?:\n|$)/;
 const EMPTY_FRONTMATTER_REGEX = /^---[ \t]*\n---[ \t]*(?:\n|$)/;
 
-// Max content size for regex operations (1MB)
-const MAX_CONTENT_SIZE = 1024 * 1024;
 
 /**
  * Parse markdown content, extracting frontmatter
@@ -24,7 +23,7 @@ export function parseContent(markdown: string): ParsedContent {
   }
 
   // Size guard to prevent regex performance issues
-  if (markdown.length > MAX_CONTENT_SIZE) {
+  if (markdown.length > MAX_FILE_SIZE) {
     return {
       frontmatter: null,
       body: markdown,

--- a/src/webview/frontmatter.ts
+++ b/src/webview/frontmatter.ts
@@ -1,0 +1,101 @@
+import matter from "gray-matter";
+
+export interface ParsedContent {
+  frontmatter: string | null;
+  body: string;
+  isValid: boolean;
+  error?: string;
+}
+
+// Max content size for regex operations (1MB)
+const MAX_CONTENT_SIZE = 1024 * 1024;
+
+/**
+ * Parse markdown content, extracting frontmatter
+ */
+export function parseContent(markdown: string): ParsedContent {
+  // Input validation
+  if (!markdown || typeof markdown !== "string") {
+    return { frontmatter: null, body: "", isValid: true };
+  }
+
+  // Size guard to prevent regex performance issues
+  if (markdown.length > MAX_CONTENT_SIZE) {
+    return {
+      frontmatter: null,
+      body: markdown,
+      isValid: true,
+      error: "Content too large for frontmatter parsing",
+    };
+  }
+
+  try {
+    const parsed = matter(markdown);
+    const hasFm = Object.keys(parsed.data).length > 0;
+
+    if (!hasFm) {
+      // Check for empty frontmatter (---\n---)
+      const emptyMatch = markdown.match(/^---\s*\n---\s*\n?/);
+      if (emptyMatch) {
+        return {
+          frontmatter: "",
+          body: markdown.slice(emptyMatch[0].length),
+          isValid: true,
+        };
+      }
+      return { frontmatter: null, body: markdown, isValid: true };
+    }
+
+    // Extract raw YAML without delimiters
+    const rawYaml = matter
+      .stringify("", parsed.data)
+      .replace(/^---\n/, "")
+      .replace(/\n---\s*$/, "")
+      .trim();
+
+    return {
+      frontmatter: rawYaml,
+      body: parsed.content,
+      isValid: true,
+    };
+  } catch (err) {
+    // Invalid YAML - try to extract raw frontmatter
+    const match = markdown.match(/^---\n([\s\S]*?)\n---\n?/);
+    if (match) {
+      return {
+        frontmatter: match[1],
+        body: markdown.slice(match[0].length),
+        isValid: false,
+        error: err instanceof Error ? err.message : "Invalid YAML",
+      };
+    }
+    return { frontmatter: null, body: markdown, isValid: true };
+  }
+}
+
+/**
+ * Reconstruct markdown from frontmatter and body
+ */
+export function reconstructContent(
+  frontmatter: string | null,
+  body: string
+): string {
+  const safeBody = body ?? "";
+  if (frontmatter === null || frontmatter.trim() === "") {
+    return safeBody;
+  }
+
+  const yaml = frontmatter.trim();
+  const bodyTrimmed = safeBody.replace(/^\n+/, "");
+  return `---\n${yaml}\n---\n\n${bodyTrimmed}`;
+}
+
+/**
+ * Quick check if content has frontmatter
+ */
+export function hasFrontmatter(markdown: string): boolean {
+  if (!markdown || typeof markdown !== "string") {
+    return false;
+  }
+  return matter.test(markdown);
+}

--- a/src/webview/frontmatter.ts
+++ b/src/webview/frontmatter.ts
@@ -27,7 +27,7 @@ export function parseContent(markdown: string): ParsedContent {
     return {
       frontmatter: null,
       body: markdown,
-      isValid: true,
+      isValid: false,
       error: "Content too large for frontmatter parsing",
     };
   }

--- a/src/webview/line-highlight-plugin.ts
+++ b/src/webview/line-highlight-plugin.ts
@@ -1,0 +1,37 @@
+import { Plugin, PluginKey } from "@milkdown/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/prose/view";
+
+const lineHighlightKey = new PluginKey("line-highlight");
+
+/**
+ * Create ProseMirror plugin that highlights current block containing cursor.
+ * Uses Decoration API to add 'line-highlight' CSS class to active block node.
+ */
+export function createLineHighlightPlugin(): Plugin {
+  return new Plugin({
+    key: lineHighlightKey,
+    props: {
+      decorations(state) {
+        const { selection } = state;
+        const { $from } = selection;
+
+        // Return empty if cursor at document root (depth 0)
+        const depth = $from.depth;
+        if (depth === 0) return DecorationSet.empty;
+
+        // Find top-level block (depth 1) containing cursor
+        const blockStart = $from.start(1);
+        const blockEnd = $from.end(1);
+
+        // Create node decoration wrapping entire block
+        // ProseMirror positions: start() returns pos after opening, end() returns pos before closing
+        // Offset -1/+1 needed to include the node wrapper itself in decoration range
+        const decoration = Decoration.node(blockStart - 1, blockEnd + 1, {
+          class: "line-highlight",
+        });
+
+        return DecorationSet.create(state.doc, [decoration]);
+      },
+    },
+  });
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -239,8 +239,26 @@ function setupMetadataHandlers(): void {
       validateAndShowError();
     });
 
-    // Ctrl/Cmd+S triggers validation
     textarea.addEventListener("keydown", (e) => {
+      // Tab inserts 2 spaces (YAML standard)
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const indent = "  ";
+
+        textarea.value =
+          textarea.value.substring(0, start) +
+          indent +
+          textarea.value.substring(end);
+        textarea.selectionStart = textarea.selectionEnd = start + indent.length;
+
+        // Trigger input for auto-resize and debounced save
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        return;
+      }
+
+      // Ctrl/Cmd+S triggers validation
       if ((e.ctrlKey || e.metaKey) && e.key === "s") {
         e.preventDefault();
         validateAndShowError();

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -242,6 +242,7 @@ function setupMetadataHandlers(): void {
     // Ctrl/Cmd+S triggers validation
     textarea.addEventListener("keydown", (e) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
         validateAndShowError();
       }
     });

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1,5 +1,10 @@
 import { Crepe } from "@milkdown/crepe";
 import "@milkdown/crepe/theme/common/style.css";
+import {
+  parseContent,
+  reconstructContent,
+  type ParsedContent,
+} from "./frontmatter";
 
 declare function acquireVsCodeApi(): {
   postMessage(message: unknown): void;
@@ -99,6 +104,7 @@ let isUpdatingFromExtension = false;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let currentTheme: ThemeName = "frame";
 let globalThemeReceived: ThemeName | null = null; // Theme from extension globalState
+let currentParsed: ParsedContent | null = null; // Current parsed frontmatter state
 
 function debouncedPostEdit(content: string): void {
   if (debounceTimer !== null) clearTimeout(debounceTimer);

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -37,6 +37,7 @@ const THEME_VARIABLES: Record<ThemeName, Record<string, string>> = {
     "--crepe-color-hover": "#e0e0e0",
     "--crepe-color-selected": "#d5d5d5",
     "--crepe-color-inline-area": "#cacaca",
+    "--crepe-color-caret": "#333333",
   },
   "frame-dark": {
     "--crepe-color-background": "#1a1a1a",
@@ -56,6 +57,7 @@ const THEME_VARIABLES: Record<ThemeName, Record<string, string>> = {
     "--crepe-color-hover": "#3a3a3a",
     "--crepe-color-selected": "#4a4a4a",
     "--crepe-color-inline-area": "#505050",
+    "--crepe-color-caret": "#ffffff",
   },
   nord: {
     "--crepe-color-background": "#fdfcff",
@@ -75,6 +77,7 @@ const THEME_VARIABLES: Record<ThemeName, Record<string, string>> = {
     "--crepe-color-hover": "#eceef4",
     "--crepe-color-selected": "#e1e2e8",
     "--crepe-color-inline-area": "#d8dae0",
+    "--crepe-color-caret": "#37618e",
   },
   "nord-dark": {
     "--crepe-color-background": "#2e3440",
@@ -94,6 +97,7 @@ const THEME_VARIABLES: Record<ThemeName, Record<string, string>> = {
     "--crepe-color-hover": "#434c5e",
     "--crepe-color-selected": "#4c566a",
     "--crepe-color-inline-area": "#4c566a",
+    "--crepe-color-caret": "#88c0d0",
   },
 };
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -168,6 +168,8 @@ function updateMetadataPanel(
     // No frontmatter - show Add button
     details.classList.add("hidden");
     addBtn.classList.remove("hidden");
+    textarea.classList.remove("error");
+    errorEl.classList.add("hidden");
   } else {
     // Has frontmatter - show panel
     details.classList.remove("hidden");
@@ -175,12 +177,14 @@ function updateMetadataPanel(
     textarea.value = frontmatter;
     autoResizeTextarea(textarea);
 
-    // Show/hide error
+    // Show/hide error with styling sync
     if (!isValid && error) {
       errorEl.textContent = `(${error})`;
       errorEl.classList.remove("hidden");
+      textarea.classList.add("error");
     } else {
       errorEl.classList.add("hidden");
+      textarea.classList.remove("error");
     }
   }
 }

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -121,6 +121,13 @@ const getThemeSelect = () =>
 const getSourceBtn = () => document.getElementById("btn-source");
 const getLoadingIndicator = () => document.getElementById("loading-indicator");
 
+// Metadata panel DOM elements
+const getMetadataDetails = () => document.getElementById("metadata-details");
+const getMetadataTextarea = () =>
+  document.getElementById("metadata-textarea") as HTMLTextAreaElement | null;
+const getAddMetadataBtn = () => document.getElementById("add-metadata-btn");
+const getMetadataError = () => document.getElementById("metadata-error");
+
 function hideLoading(): void {
   const loading = getLoadingIndicator();
   if (loading) {
@@ -133,6 +140,22 @@ function showLoading(): void {
   if (loading) {
     loading.classList.remove("hidden");
   }
+}
+
+// Metadata panel auto-resize
+function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.style.height = "auto";
+  const newHeight = Math.min(Math.max(textarea.scrollHeight, 80), 300);
+  textarea.style.height = `${newHeight}px`;
+}
+
+function setupMetadataTextareaHandlers(): void {
+  const textarea = getMetadataTextarea();
+  if (!textarea) return;
+
+  textarea.addEventListener("input", () => {
+    autoResizeTextarea(textarea);
+  });
 }
 
 function escapeHtml(text: string): string {
@@ -375,6 +398,7 @@ function init() {
   console.log("[Crepe] init() called");
 
   setupToolbarHandlers();
+  setupMetadataTextareaHandlers();
 
   // Don't create editor yet - wait for content from extension
   // This prevents showing empty placeholder "Please enter..."


### PR DESCRIPTION
## Summary

Add a collapsible metadata panel above the Milkdown editor for viewing and editing YAML frontmatter.

### Features
- **Collapsible panel** with details/summary for expand/collapse
- **Bidirectional sync** between metadata panel and Milkdown editor
- **YAML validation** on blur with line number error display
- **"Add Metadata" button** when no frontmatter exists
- **Theme-consistent styling** with VSCode variables

### Implementation
- **Phase 1**: Added `gray-matter` dependency for YAML parsing
- **Phase 2**: Created `src/webview/frontmatter.ts` with parsing utilities
- **Phase 3**: Added panel HTML + CSS to `markdownEditorProvider.ts`
- **Phase 4**: Wired bidirectional sync in `main.ts`
- **Phase 5**: Added error handling and validation

### Files Changed
- `src/webview/frontmatter.ts` (new) - Parsing utilities
- `src/webview/main.ts` - Metadata panel logic
- `src/markdownEditorProvider.ts` - HTML template + CSS
- `package.json` - Added gray-matter dependency

### Test Plan
- [ ] Open .md file with frontmatter → panel shows metadata
- [ ] Open .md file without frontmatter → "Add Metadata" button shows
- [ ] Edit metadata → file updates correctly
- [ ] Edit body in Milkdown → frontmatter preserved
- [ ] Invalid YAML → error indicator with line number
- [ ] Clear metadata → frontmatter removed from file
- [ ] Collapse/expand panel works
- [ ] Theme switching maintains styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor line highlight with theme support and toggle setting
  * Responsive max-width layout for improved readability on large displays
  * Collapsible metadata panel for editing YAML frontmatter with bidirectional sync
  * "Add Metadata" button and Tab key indentation (2 spaces) in metadata textarea
  * Clearing metadata removes frontmatter from the document

* **Validation**
  * YAML validation with line-numbered error display

* **Chores**
  * Release bumped to 1.3.0; added YAML parsing/validation support and docs/config updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->