### PR TITLE
feat(image): comprehensive image upload, editing, and auto-management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
 ### Changed
 
+* Image edit icon now shows when hovering anywhere on image block (not just the image itself)
 * Extended `localResourceRoots` to include document folder and workspace for image loading
 
 ## \[1.4.0] - 2026-01-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
   * Supports both relative and absolute paths
   * Automatic path resolution for webview display
 
+* **Image URL Editing**
+  * Hover on image to show edit icon (pencil button)
+  * Double-click on image to edit URL/path via VSCode input box
+  * Shows original path instead of webview URI
+
+* **Auto Rename Images**
+  * Automatically rename image files when you change the path in markdown
+  * Only triggers when image folder remains the same
+  * Updates all references in workspace `.md` files
+  * Configurable via `tuiMarkdown.autoRenameImages` setting (default: true)
+
+* **Auto Delete Images**
+  * Automatically delete image files when removed from markdown
+  * Moves files to Trash (recoverable)
+  * Shows warning if image is used in other `.md` files
+  * Configurable via `tuiMarkdown.autoDeleteImages` setting (default: true)
+
 ### Changed
 
 * Extended `localResourceRoots` to include document folder and workspace for image loading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
   * Shows warning if image is used in other `.md` files
   * Configurable via `tuiMarkdown.autoDeleteImages` setting (default: true)
 
+### Fixed
+
+* Fixed cursor position lost when deleting images (editor no longer recreates on imageMap changes from user edits)
+
 ### Changed
 
 * Extended `localResourceRoots` to include document folder and workspace for image loading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.5.0] - 2026-01-24
+
+### Added
+
+* **Image Upload & Paste Support**
+  * Paste images from clipboard directly into the editor
+  * Upload images via Crepe's file picker button
+  * Images saved automatically to configurable folder
+  * Configurable via `tuiMarkdown.imageSaveFolder` setting (default: `images`)
+  * Use `.` for same folder as document
+
+* **Local Image Display**
+  * Renders local images from document folder and workspace
+  * Supports both relative and absolute paths
+  * Automatic path resolution for webview display
+
+### Changed
+
+* Extended `localResourceRoots` to include document folder and workspace for image loading
+
 ## \[1.4.0] - 2026-01-24
 
 ### Added
@@ -96,4 +116,3 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 * Configurable font size (8-32px)
 
 * Support for .md and .markdown files
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Extension provides these settings via `tuiMarkdown.*` namespace:
 - Font size (8-32px), heading sizes H1-H6 (12-72px)
 - `highlightCurrentLine` (boolean, default: true) - Enable cursor line highlight
 - `imageSaveFolder` (string, default: `images`) - Folder to save pasted images (relative to document)
+- `autoRenameImages` (boolean, default: true) - Automatically rename image files when you change the image path in markdown (only when folder stays the same)
 
 ## Milkdown Crepe Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,3 +145,10 @@ Uses `@milkdown/crepe` package. Theme CSS variables loaded from `src/webview/the
 **Path Transformation**:
 - On load: Local paths → webview URIs (for display)
 - On save: Webview URIs → original paths (preserve markdown)
+
+**Auto Rename Images** (`src/markdownEditorProvider.ts`):
+- When user edits image path in markdown (same folder, different filename)
+- On save: Extension detects path change and prompts user via QuickPick dialog
+- If confirmed: Renames image file on disk, updates all `.md` files in workspace with new path
+- Controlled by `tuiMarkdown.autoRenameImages` setting (boolean, default: true)
+- Only triggers when image folder remains the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,15 +19,21 @@ npm run package    # Package extension as .vsix
 ## Architecture
 
 **Dual-bundle build** using esbuild (`esbuild.config.js`):
-- Extension bundle: `src/extension.ts` → `out/extension.js` (CJS, Node platform)
-- Webview bundle: `src/webview/main.ts` → `out/webview/main.js` (IIFE, browser platform)
+
+* Extension bundle: `src/extension.ts` → `out/extension.js` (CJS, Node platform)
+
+* Webview bundle: `src/webview/main.ts` → `out/webview/main.js` (IIFE, browser platform)
 
 **Build configuration**:
-- Production mode (default): minified bundles, no sourcemaps, tree-shaking enabled
-- Development mode (`--dev` flag): sourcemaps enabled, unminified, tree-shaking enabled
-- Watch mode (`--watch` flag): rebuilds on file changes, sourcemaps enabled
+
+* Production mode (default): minified bundles, no sourcemaps, tree-shaking enabled
+
+* Development mode (`--dev` flag): sourcemaps enabled, unminified, tree-shaking enabled
+
+* Watch mode (`--watch` flag): rebuilds on file changes, sourcemaps enabled
 
 **Extension ↔ Webview communication flow:**
+
 1. Extension registers `CustomTextEditorProvider` for `.md` files
 2. When document opens, provider creates webview with HTML template containing editor container
 3. Webview sends `ready` → Extension sends `theme`, `config`, `update` (content)
@@ -35,10 +41,14 @@ npm run package    # Package extension as .vsix
 5. External document changes → Extension sends `update` → Webview recreates Crepe instance
 
 **Key implementation details:**
-- `pendingEdit` flag prevents edit loops between extension and webview
-- Webview persists theme selection in `vscode.setState()`
-- Large files (>500KB) show warning dialog
-- CSP uses nonce for script execution
+
+* `pendingEdit` flag prevents edit loops between extension and webview
+
+* Webview persists theme selection in `vscode.setState()`
+
+* Large files (>500KB) show warning dialog
+
+* CSP uses nonce for script execution
 
 ## File Structure
 
@@ -52,6 +62,7 @@ src/
     ├── main.ts               # Browser-side Milkdown Crepe editor
     ├── frontmatter.ts        # YAML parsing & validation utilities
     ├── line-highlight-plugin.ts # ProseMirror plugin for cursor line highlight
+    ├── image-edit-plugin.ts  # Double-click image URL editing
     └── themes/               # Theme CSS files (scoped by body class)
         ├── index.css              # Imports all theme CSS
         ├── frame.css              # Frame light theme
@@ -69,10 +80,16 @@ src/
 ## Configuration Settings
 
 Extension provides these settings via `tuiMarkdown.*` namespace:
-- Font size (8-32px), heading sizes H1-H6 (12-72px)
-- `highlightCurrentLine` (boolean, default: true) - Enable cursor line highlight
-- `imageSaveFolder` (string, default: `images`) - Folder to save pasted images (relative to document)
-- `autoRenameImages` (boolean, default: true) - Automatically rename image files when you change the image path in markdown (only when folder stays the same)
+
+* Font size (8-32px), heading sizes H1-H6 (12-72px)
+
+* `highlightCurrentLine` (boolean, default: true) - Enable cursor line highlight
+
+* `imageSaveFolder` (string, default: `images`) - Folder to save pasted images (relative to document)
+
+* `autoRenameImages` (boolean, default: true) - Automatically rename image files when you change the image path in markdown (only when folder stays the same)
+
+* `autoDeleteImages` (boolean, default: true) - Automatically delete image files when removed from markdown (moves to Trash, warns if used elsewhere)
 
 ## Milkdown Crepe Integration
 
@@ -81,19 +98,29 @@ Uses `@milkdown/crepe` package. Theme CSS variables loaded from `src/webview/the
 ## Metadata Panel
 
 **Frontmatter Handling** (`src/webview/frontmatter.ts`):
-- Parses and validates YAML frontmatter using `js-yaml` library
-- Returns validation errors with line numbers
-- Reconstructs markdown with frontmatter delimiters (`---`)
-- Handles edge cases: empty frontmatter, missing delimiters, invalid YAML
+
+* Parses and validates YAML frontmatter using `js-yaml` library
+
+* Returns validation errors with line numbers
+
+* Reconstructs markdown with frontmatter delimiters (`---`)
+
+* Handles edge cases: empty frontmatter, missing delimiters, invalid YAML
 
 **Panel UI** (integrated in `src/markdownEditorProvider.ts` HTML):
-- Collapsible `<details>` element styled with VSCode theme variables
-- Textarea for YAML editing with syntax error display (red border + error message)
-- Tab key inserts 2 spaces (YAML standard indentation)
-- "Add Metadata" button when no frontmatter exists
-- Panel integrates seamlessly below toolbar, above editor
+
+* Collapsible `<details>` element styled with VSCode theme variables
+
+* Textarea for YAML editing with syntax error display (red border + error message)
+
+* Tab key inserts 2 spaces (YAML standard indentation)
+
+* "Add Metadata" button when no frontmatter exists
+
+* Panel integrates seamlessly below toolbar, above editor
 
 **Bidirectional Sync**:
+
 1. Document opens → Parse content → Show metadata panel (or "Add Metadata" button)
 2. User edits metadata textarea → Validates YAML → Updates document (triggers `edit` message)
 3. External document change → Reparse → Refresh metadata display
@@ -104,51 +131,105 @@ Uses `@milkdown/crepe` package. Theme CSS variables loaded from `src/webview/the
 ## Line Highlight
 
 **Plugin** (`src/webview/line-highlight-plugin.ts`):
-- ProseMirror plugin using Decoration API
-- Highlights immediate block containing cursor (paragraph, heading, list item)
-- Skips code blocks (they have built-in line highlighting from CodeMirror)
-- Injected via `prosePluginsCtx` before Crepe instance creation
+
+* ProseMirror plugin using Decoration API
+
+* Highlights immediate block containing cursor (paragraph, heading, list item)
+
+* Skips code blocks (they have built-in line highlighting from CodeMirror)
+
+* Injected via `prosePluginsCtx` before Crepe instance creation
 
 **CSS** (in `src/markdownEditorProvider.ts`):
-- Uses `::before` pseudo-element with `z-index: -1` stacking
-- Light themes (`theme-frame`, `theme-nord`, `theme-crepe`, `theme-catppuccin-latte`): `rgba(0, 0, 0, 0.08)` background
-- Dark themes (`theme-frame-dark`, `theme-nord-dark`, `theme-crepe-dark`, `theme-catppuccin-frappe`, `theme-catppuccin-macchiato`, `theme-catppuccin-mocha`): `rgba(255, 255, 255, 0.08)`
+
+* Uses `::before` pseudo-element with `z-index: -1` stacking
+
+* Light themes (`theme-frame`, `theme-nord`, `theme-crepe`, `theme-catppuccin-latte`): `rgba(0, 0, 0, 0.08)` background
+
+* Dark themes (`theme-frame-dark`, `theme-nord-dark`, `theme-crepe-dark`, `theme-catppuccin-frappe`, `theme-catppuccin-macchiato`, `theme-catppuccin-mocha`): `rgba(255, 255, 255, 0.08)`
 
 ## Table Styling
 
 **CSS** (in `src/markdownEditorProvider.ts`):
-- `table-layout: auto` - Columns size proportionally to content
-- `width: 100%` - Table spans full editor width
-- `white-space: normal`, `word-wrap: break-word`, `overflow-wrap: break-word` - Cell text wraps naturally for responsive display
+
+* `table-layout: auto` - Columns size proportionally to content
+
+* `width: 100%` - Table spans full editor width
+
+* `white-space: normal`, `word-wrap: break-word`, `overflow-wrap: break-word` - Cell text wraps naturally for responsive display
 
 ## Image Handling
 
 **Local Image Display** (`src/markdownEditorProvider.ts`):
-- `extractImagePaths()`: Extracts image paths from markdown (both `![](path)` and `<img src="">`)
-- `resolveImagePath()`: Resolves relative/absolute paths against document location
-- `buildImageMap()`: Creates mapping from original paths to webview URIs
-- `localResourceRoots` includes document folder and workspace for image access
+
+* `extractImagePaths()`: Extracts image paths from markdown (both `![](path)` and `<img src="">`)
+
+* `resolveImagePath()`: Resolves relative/absolute paths against document location
+
+* `buildImageMap()`: Creates mapping from original paths to webview URIs
+
+* `localResourceRoots` includes document folder and workspace for image access
 
 **Image Upload** (`src/webview/main.ts`):
-- Paste from clipboard: Intercepts paste events with image data
-- Crepe file picker: Uses `onUpload` callback for image uploads
-- Converts images to base64, sends to extension for saving
-- Extension saves to configured folder (`tuiMarkdown.imageSaveFolder`)
-- Returns saved path, updates markdown with relative path
+
+* Paste from clipboard: Intercepts paste events with image data
+
+* Crepe file picker: Uses `onUpload` callback for image uploads
+
+* Converts images to base64, sends to extension for saving
+
+* Extension saves to configured folder (`tuiMarkdown.imageSaveFolder`)
+
+* Returns saved path, updates markdown with relative path
 
 **Message Flow**:
+
 1. Webview detects image (paste or upload) → converts to base64
 2. Sends `saveImage` message with base64 data and filename
 3. Extension saves to disk, returns `imageSaved` with relative path
 4. Webview updates markdown content with new image path
 
 **Path Transformation**:
-- On load: Local paths → webview URIs (for display)
-- On save: Webview URIs → original paths (preserve markdown)
+
+* On load: Local paths → webview URIs (for display)
+
+* On save: Webview URIs → original paths (preserve markdown)
 
 **Auto Rename Images** (`src/markdownEditorProvider.ts`):
-- When user edits image path in markdown (same folder, different filename)
-- On save: Extension detects path change and prompts user via QuickPick dialog
-- If confirmed: Renames image file on disk, updates all `.md` files in workspace with new path
-- Controlled by `tuiMarkdown.autoRenameImages` setting (boolean, default: true)
-- Only triggers when image folder remains the same
+
+* When user edits image path in markdown (same folder, different filename)
+
+* On save: Extension detects path change and prompts user via QuickPick dialog
+
+* If confirmed: Renames image file on disk, updates all `.md` files in workspace with new path
+
+* Controlled by `tuiMarkdown.autoRenameImages` setting (boolean, default: true)
+
+* Only triggers when image folder remains the same
+
+**Auto Delete Images** (`src/markdownEditorProvider.ts` + `src/utils/image-rename-handler.ts`):
+
+* When user removes image from markdown (path no longer exists in document)
+
+* On save: Extension detects removed images and prompts user via QuickPick dialog
+
+* Shows warning icon if image is used in other `.md` files in workspace
+
+* If confirmed: Moves image file to Trash (can be recovered)
+
+* Controlled by `tuiMarkdown.autoDeleteImages` setting (boolean, default: true)
+
+**Image URL Editing** (`src/webview/image-edit-plugin.ts`):
+
+* Double-click on image opens VSCode input box to edit URL/path
+
+* DOM event listener (capture phase) intercepts before Milkdown components
+
+* Finds ProseMirror node via `posAtDOM()` and position search
+
+* Uses async message flow: webview → extension (showInputBox) → webview
+
+* Reverse lookup from imageMap to display original path instead of webview URI
+
+* Updates node via ProseMirror transaction after user confirms
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 - **Cursor Line Highlight**: Visual highlight of current block/paragraph
 - **Metadata Panel**: Collapsible YAML frontmatter editor with validation
 - **Image Upload**: Paste images from clipboard or upload via file picker
+- **Image URL Editing**: Double-click on image to edit URL/path
+- **Auto Rename Images**: Automatically rename image files when you change the path in markdown
+- **Auto Delete Images**: Automatically delete image files when removed from markdown (moves to Trash)
 - **Local Image Display**: Renders local images from document folder and workspace
 - **Large File Warning**: Protection for files >500KB
 - **Configurable Font Size**: Adjust editor font size (8-32px)
@@ -31,6 +34,8 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 | `tuiMarkdown.fontSize` | 16 | Editor font size (8-32px) |
 | `tuiMarkdown.highlightCurrentLine` | true | Enable cursor line highlight |
 | `tuiMarkdown.imageSaveFolder` | `images` | Folder to save pasted images (relative to document) |
+| `tuiMarkdown.autoRenameImages` | true | Auto rename image files when path changes in markdown |
+| `tuiMarkdown.autoDeleteImages` | true | Auto delete image files when removed from markdown (moves to Trash) |
 | `tuiMarkdown.headingSizes.h1` | 32 | H1 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h2` | 28 | H2 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h3` | 24 | H3 heading font size (12-72px) |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 - **View Source**: Toggle between WYSIWYG and source view
 - **Cursor Line Highlight**: Visual highlight of current block/paragraph
 - **Metadata Panel**: Collapsible YAML frontmatter editor with validation
+- **Image Upload**: Paste images from clipboard or upload via file picker
+- **Local Image Display**: Renders local images from document folder and workspace
 - **Large File Warning**: Protection for files >500KB
 - **Configurable Font Size**: Adjust editor font size (8-32px)
 - **Configurable Heading Sizes**: Customize font sizes for H1-H6 headings (12-72px)
@@ -28,6 +30,7 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Milkdown Crepe.
 |---------|---------|-------------|
 | `tuiMarkdown.fontSize` | 16 | Editor font size (8-32px) |
 | `tuiMarkdown.highlightCurrentLine` | true | Enable cursor line highlight |
+| `tuiMarkdown.imageSaveFolder` | `images` | Folder to save pasted images (relative to document) |
 | `tuiMarkdown.headingSizes.h1` | 32 | H1 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h2` | 28 | H2 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h3` | 24 | H3 heading font size (12-72px) |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "Milkdown Markdown WYSIWYG",
   "description": "A beautiful WYSIWYG Markdown editor powered by Milkdown Crepe. Edit markdown files with rich text experience and theme selection.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",
@@ -88,6 +88,11 @@
           "type": "boolean",
           "default": true,
           "description": "Highlight the line containing the cursor in the editor"
+        },
+        "tuiMarkdown.imageSaveFolder": {
+          "type": "string",
+          "default": "images",
+          "description": "Folder to save pasted images (relative to document). Use '.' for same folder as document."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
           "type": "string",
           "default": "images",
           "description": "Folder to save pasted images (relative to document). Use '.' for same folder as document."
+        },
+        "tuiMarkdown.autoRenameImages": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically rename image files when you change the image path in markdown (only when folder stays the same)"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically rename image files when you change the image path in markdown (only when folder stays the same)"
+        },
+        "tuiMarkdown.autoDeleteImages": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically delete image files when removed from markdown (moves to trash)"
         }
       }
     },

--- a/src/utils/image-rename-handler.ts
+++ b/src/utils/image-rename-handler.ts
@@ -1,0 +1,85 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+
+/**
+ * Represents an image rename operation detected from path changes.
+ */
+export interface ImageRename {
+  oldRelative: string; // Original relative path in markdown
+  newRelative: string; // New relative path in markdown
+  oldAbsolute: string; // Source file absolute path
+  newAbsolute: string; // Target file absolute path
+}
+
+/**
+ * Normalize path separators for cross-platform comparison.
+ */
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Detect image renames by comparing original paths with current paths.
+ * Only detects renames within the same folder (different filename, same directory).
+ */
+export function detectImageRenames(
+  originalPaths: Map<string, string>,
+  currentPaths: string[],
+  documentUri: vscode.Uri,
+): ImageRename[] {
+  try {
+    const renames: ImageRename[] = [];
+    const docDir = path.dirname(documentUri.fsPath);
+    const seenOldPaths = new Set<string>(); // Dedupe by source path
+    const seenNewPaths = new Set<string>(); // Dedupe by target path
+
+    for (const currentPath of currentPaths) {
+      // Normalize for comparison
+      const normalizedCurrent = normalizePath(currentPath);
+
+      // Skip if current path exists in original (no rename)
+      const hasOriginal = [...originalPaths.keys()].some(
+        (k) => normalizePath(k) === normalizedCurrent,
+      );
+      if (hasOriginal) continue;
+
+      const currentDir = normalizePath(path.dirname(currentPath));
+      const currentFilename = path.basename(currentPath);
+
+      for (const [origRelative, origAbsolute] of originalPaths) {
+        // Skip already processed
+        if (seenOldPaths.has(origAbsolute)) continue;
+
+        const origDir = normalizePath(path.dirname(origRelative));
+        const origFilename = path.basename(origRelative);
+
+        // Same folder, different filename = rename
+        if (currentDir === origDir && currentFilename !== origFilename) {
+          // Verify source file exists
+          if (fs.existsSync(origAbsolute)) {
+            const newAbsolute = path.resolve(docDir, currentPath);
+
+            // Skip if target already used (prevent multiple → one overwrite)
+            if (seenNewPaths.has(newAbsolute)) continue;
+
+            renames.push({
+              oldRelative: origRelative,
+              newRelative: currentPath,
+              oldAbsolute: origAbsolute,
+              newAbsolute: newAbsolute,
+            });
+            seenOldPaths.add(origAbsolute);
+            seenNewPaths.add(newAbsolute);
+            break; // One source maps to one target
+          }
+        }
+      }
+    }
+
+    return renames;
+  } catch (err) {
+    console.error("[Image Rename] Detection failed:", err);
+    return [];
+  }
+}

--- a/src/utils/image-rename-handler.ts
+++ b/src/utils/image-rename-handler.ts
@@ -13,10 +13,16 @@ export interface ImageRename {
 }
 
 /**
- * Normalize path separators for cross-platform comparison.
+ * Normalize path for comparison.
+ * - Replaces backslashes with forward slashes
+ * - Removes leading ./ prefix
+ * - Handles multiple consecutive slashes
  */
-function normalizePath(p: string): string {
-  return p.replace(/\\/g, "/");
+export function normalizePath(p: string): string {
+  return p
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/\/+/g, "/");
 }
 
 /**
@@ -29,15 +35,21 @@ function isPathWithinDir(resolvedPath: string, allowedDir: string): boolean {
 }
 
 /**
- * Check if path contains traversal patterns.
+ * Check if path contains traversal or absolute patterns.
+ * Only allow relative paths for rename detection.
  */
-function hasPathTraversal(p: string): boolean {
+export function hasPathTraversal(p: string): boolean {
+  // Block: parent traversal, absolute paths (Unix and Windows)
   return p.includes("..") || p.startsWith("/") || /^[a-zA-Z]:/.test(p);
 }
 
 /**
  * Detect image renames by comparing original paths with current paths.
  * Only detects renames within the same folder (different filename, same directory).
+ *
+ * IMPORTANT: Only considers original paths that have been REMOVED from document
+ * as potential rename sources. This prevents false positives when pasting
+ * multiple new images into the same folder.
  */
 export function detectImageRenames(
   originalPaths: Map<string, string>,
@@ -50,6 +62,32 @@ export function detectImageRenames(
     const seenOldPaths = new Set<string>(); // Dedupe by source path
     const seenNewPaths = new Set<string>(); // Dedupe by target path
 
+    console.log("[Image Rename] Detecting renames...");
+    console.log("[Image Rename] Original paths:", [...originalPaths.entries()]);
+    console.log("[Image Rename] Current paths:", currentPaths);
+
+    // Build set of normalized current paths for quick lookup
+    const normalizedCurrentSet = new Set(
+      currentPaths.map((p) => normalizePath(p)),
+    );
+
+    // Find original paths that have been REMOVED from document
+    // Only these can be sources of rename operations
+    const removedOriginals = new Map<string, string>();
+    for (const [origRelative, origAbsolute] of originalPaths) {
+      if (!normalizedCurrentSet.has(normalizePath(origRelative))) {
+        removedOriginals.set(origRelative, origAbsolute);
+      }
+    }
+
+    console.log("[Image Rename] Removed originals:", [...removedOriginals.entries()]);
+
+    // No removed paths = no renames possible
+    if (removedOriginals.size === 0) {
+      console.log("[Image Rename] No removed paths, skipping rename detection");
+      return [];
+    }
+
     for (const currentPath of currentPaths) {
       // Normalize for comparison
       const normalizedCurrent = normalizePath(currentPath);
@@ -58,25 +96,36 @@ export function detectImageRenames(
       const hasOriginal = [...originalPaths.keys()].some(
         (k) => normalizePath(k) === normalizedCurrent,
       );
-      if (hasOriginal) continue;
+      if (hasOriginal) {
+        console.log("[Image Rename] Path unchanged:", currentPath);
+        continue;
+      }
 
       // Security: Skip paths with traversal patterns
-      if (hasPathTraversal(currentPath)) continue;
+      if (hasPathTraversal(currentPath)) {
+        console.log("[Image Rename] Skipping path with traversal:", currentPath);
+        continue;
+      }
 
       const currentDir = normalizePath(path.dirname(currentPath));
       const currentFilename = path.basename(currentPath);
+      console.log("[Image Rename] New path - dir:", currentDir, "filename:", currentFilename);
 
-      for (const [origRelative, origAbsolute] of originalPaths) {
+      // Only match with REMOVED original paths (not all originals)
+      for (const [origRelative, origAbsolute] of removedOriginals) {
         // Skip already processed
         if (seenOldPaths.has(origAbsolute)) continue;
 
         const origDir = normalizePath(path.dirname(origRelative));
         const origFilename = path.basename(origRelative);
+        console.log("[Image Rename] Comparing with removed - dir:", origDir, "filename:", origFilename);
 
         // Same folder, different filename = rename
         if (currentDir === origDir && currentFilename !== origFilename) {
+          console.log("[Image Rename] Folder match! Checking if source exists:", origAbsolute);
           // Verify source file exists
           if (fs.existsSync(origAbsolute)) {
+            console.log("[Image Rename] Source file exists, adding rename");
             const newAbsolute = path.resolve(docDir, currentPath);
 
             // Security: Verify target is within document directory
@@ -107,31 +156,6 @@ export function detectImageRenames(
 }
 
 /**
- * Show confirmation dialog for image renames.
- * Returns selected renames or undefined if cancelled.
- */
-export async function showRenameConfirmation(
-  renames: ImageRename[],
-): Promise<ImageRename[] | undefined> {
-  const items = renames.map((r) => ({
-    label: `$(file) ${path.basename(r.oldRelative)}`,
-    description: `→ ${path.basename(r.newRelative)}`,
-    detail: path.dirname(r.oldRelative) || ".",
-    rename: r,
-    picked: true,
-  }));
-
-  const selected = await vscode.window.showQuickPick(items, {
-    canPickMany: true,
-    title: "Rename Image Files?",
-    placeHolder: "Select files to rename (ESC to cancel)",
-  });
-
-  if (!selected || selected.length === 0) return undefined;
-  return selected.map((s) => s.rename);
-}
-
-/**
  * Execute image renames on disk with conflict handling.
  */
 export async function executeImageRenames(renames: ImageRename[]): Promise<{
@@ -145,6 +169,14 @@ export async function executeImageRenames(renames: ImageRename[]): Promise<{
     try {
       const sourceUri = vscode.Uri.file(rename.oldAbsolute);
       const targetUri = vscode.Uri.file(rename.newAbsolute);
+
+      // Create parent directory if not exists
+      const targetDir = vscode.Uri.file(path.dirname(rename.newAbsolute));
+      try {
+        await vscode.workspace.fs.createDirectory(targetDir);
+      } catch {
+        // Directory may already exist
+      }
 
       // Check if target exists
       try {
@@ -204,7 +236,9 @@ export async function updateWorkspaceReferences(
         const newRef = rename.newRelative;
 
         if (text.includes(oldRef)) {
-          text = text.split(oldRef).join(newRef);
+          // Escape regex special chars for safe replacement
+          const escapedOld = oldRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          text = text.replace(new RegExp(escapedOld, "g"), newRef);
           modified = true;
         }
       }
@@ -219,4 +253,180 @@ export async function updateWorkspaceReferences(
   }
 
   return updatedCount;
+}
+
+// ============================================================================
+// Image Delete Detection & Execution
+// ============================================================================
+
+/**
+ * Represents an image delete operation detected from path removal.
+ */
+export interface ImageDelete {
+  relativePath: string; // Relative path in markdown
+  absolutePath: string; // Absolute file path on disk
+  usedInFiles: string[]; // Other files using this image (for warning)
+}
+
+/**
+ * Detect deleted images by comparing original paths with current paths.
+ * An image is considered deleted if it was in original but not in current.
+ *
+ * NOTE: If an image with the same filename exists in current paths but in a
+ * different folder, it's considered a "move" operation and NOT deleted.
+ * This prevents accidental deletion when user moves images to different folders.
+ */
+export function detectImageDeletes(
+  originalPaths: Map<string, string>,
+  currentPaths: string[],
+): ImageDelete[] {
+  try {
+    const deletes: ImageDelete[] = [];
+    const normalizedCurrentPaths = new Set(
+      currentPaths.map((p) => normalizePath(p)),
+    );
+    // Build set of current filenames for "move" detection
+    const currentFilenames = new Set(
+      currentPaths.map((p) => path.basename(p).toLowerCase()),
+    );
+
+    console.log("[Image Delete] Detecting deletes...");
+    console.log("[Image Delete] Original paths:", [...originalPaths.entries()]);
+    console.log("[Image Delete] Current paths:", currentPaths);
+    console.log("[Image Delete] Normalized current paths:", [...normalizedCurrentPaths]);
+
+    for (const [origRelative, origAbsolute] of originalPaths) {
+      const normalizedOrig = normalizePath(origRelative);
+      console.log("[Image Delete] Checking:", origRelative, "→ normalized:", normalizedOrig);
+
+      // If original path not in current paths → potentially deleted
+      if (!normalizedCurrentPaths.has(normalizedOrig)) {
+        const origFilename = path.basename(origRelative).toLowerCase();
+
+        // Check if same filename exists in different folder (move operation)
+        if (currentFilenames.has(origFilename)) {
+          console.log("[Image Delete] Same filename found in different folder, skipping (move):", origRelative);
+          continue;
+        }
+
+        console.log("[Image Delete] Path not in current, checking file exists:", origAbsolute);
+        // Verify file exists before suggesting delete
+        if (fs.existsSync(origAbsolute)) {
+          console.log("[Image Delete] File exists, adding to deletes:", origRelative);
+          deletes.push({
+            relativePath: origRelative,
+            absolutePath: origAbsolute,
+            usedInFiles: [], // Will be populated by caller
+          });
+        } else {
+          console.log("[Image Delete] File not found on disk:", origAbsolute);
+        }
+      } else {
+        console.log("[Image Delete] Path still in current (no delete):", origRelative);
+      }
+    }
+
+    console.log("[Image Delete] Detected deletes:", deletes.length);
+    return deletes;
+  } catch (err) {
+    console.error("[Image Delete] Detection failed:", err);
+    return [];
+  }
+}
+
+/**
+ * Find all markdown files in workspace that reference the given image path.
+ */
+export async function findFilesUsingImage(
+  imagePath: string,
+  excludeUri: vscode.Uri,
+): Promise<string[]> {
+  const mdFiles = await vscode.workspace.findFiles(
+    "**/*.md",
+    "**/node_modules/**",
+  );
+  const filesUsingImage: string[] = [];
+  const imageFilename = path.basename(imagePath);
+
+  for (const fileUri of mdFiles) {
+    // Skip current document
+    if (fileUri.toString() === excludeUri.toString()) continue;
+
+    try {
+      const content = await vscode.workspace.fs.readFile(fileUri);
+      const text = Buffer.from(content).toString("utf8");
+
+      // Check if file contains reference to this image (by filename)
+      if (text.includes(imageFilename)) {
+        filesUsingImage.push(
+          vscode.workspace.asRelativePath(fileUri, false),
+        );
+      }
+    } catch {
+      // Skip files that can't be read
+    }
+  }
+
+  return filesUsingImage;
+}
+
+/**
+ * Show confirmation dialog for image deletes.
+ * Shows warning for images used in other files.
+ */
+export async function showDeleteConfirmation(
+  deletes: ImageDelete[],
+): Promise<ImageDelete[] | undefined> {
+  const items = deletes.map((d) => {
+    const hasWarning = d.usedInFiles.length > 0;
+    const icon = hasWarning ? "$(warning)" : "$(trash)";
+    const detail = hasWarning
+      ? `⚠️ Also used in: ${d.usedInFiles.join(", ")}`
+      : path.dirname(d.relativePath) || ".";
+
+    return {
+      label: `${icon} ${path.basename(d.relativePath)}`,
+      description: hasWarning ? "(used elsewhere)" : "",
+      detail,
+      delete: d,
+      picked: true,
+    };
+  });
+
+  const selected = await vscode.window.showQuickPick(items, {
+    canPickMany: true,
+    title: "Delete Image Files?",
+    placeHolder: "Select files to delete - will be moved to Trash (ESC to cancel)",
+  });
+
+  if (!selected || selected.length === 0) return undefined;
+  return selected.map((s) => s.delete);
+}
+
+/**
+ * Execute image deletes by moving files to trash.
+ */
+export async function executeImageDeletes(deletes: ImageDelete[]): Promise<{
+  succeeded: string[];
+  failed: Array<{ path: string; error: string }>;
+}> {
+  const succeeded: string[] = [];
+  const failed: Array<{ path: string; error: string }> = [];
+
+  for (const del of deletes) {
+    try {
+      const fileUri = vscode.Uri.file(del.absolutePath);
+
+      // Move to trash (useTrash: true)
+      await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+      succeeded.push(del.relativePath);
+    } catch (err) {
+      failed.push({
+        path: del.relativePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { succeeded, failed };
 }

--- a/src/utils/image-rename-handler.ts
+++ b/src/utils/image-rename-handler.ts
@@ -20,6 +20,22 @@ function normalizePath(p: string): string {
 }
 
 /**
+ * Check if resolved path is within allowed directory (prevents path traversal).
+ */
+function isPathWithinDir(resolvedPath: string, allowedDir: string): boolean {
+  const normalized = path.resolve(resolvedPath);
+  const normalizedDir = path.resolve(allowedDir);
+  return normalized.startsWith(normalizedDir + path.sep) || normalized === normalizedDir;
+}
+
+/**
+ * Check if path contains traversal patterns.
+ */
+function hasPathTraversal(p: string): boolean {
+  return p.includes("..") || p.startsWith("/") || /^[a-zA-Z]:/.test(p);
+}
+
+/**
  * Detect image renames by comparing original paths with current paths.
  * Only detects renames within the same folder (different filename, same directory).
  */
@@ -44,6 +60,9 @@ export function detectImageRenames(
       );
       if (hasOriginal) continue;
 
+      // Security: Skip paths with traversal patterns
+      if (hasPathTraversal(currentPath)) continue;
+
       const currentDir = normalizePath(path.dirname(currentPath));
       const currentFilename = path.basename(currentPath);
 
@@ -59,6 +78,9 @@ export function detectImageRenames(
           // Verify source file exists
           if (fs.existsSync(origAbsolute)) {
             const newAbsolute = path.resolve(docDir, currentPath);
+
+            // Security: Verify target is within document directory
+            if (!isPathWithinDir(newAbsolute, docDir)) continue;
 
             // Skip if target already used (prevent multiple → one overwrite)
             if (seenNewPaths.has(newAbsolute)) continue;
@@ -82,4 +104,119 @@ export function detectImageRenames(
     console.error("[Image Rename] Detection failed:", err);
     return [];
   }
+}
+
+/**
+ * Show confirmation dialog for image renames.
+ * Returns selected renames or undefined if cancelled.
+ */
+export async function showRenameConfirmation(
+  renames: ImageRename[],
+): Promise<ImageRename[] | undefined> {
+  const items = renames.map((r) => ({
+    label: `$(file) ${path.basename(r.oldRelative)}`,
+    description: `→ ${path.basename(r.newRelative)}`,
+    detail: path.dirname(r.oldRelative) || ".",
+    rename: r,
+    picked: true,
+  }));
+
+  const selected = await vscode.window.showQuickPick(items, {
+    canPickMany: true,
+    title: "Rename Image Files?",
+    placeHolder: "Select files to rename (ESC to cancel)",
+  });
+
+  if (!selected || selected.length === 0) return undefined;
+  return selected.map((s) => s.rename);
+}
+
+/**
+ * Execute image renames on disk with conflict handling.
+ */
+export async function executeImageRenames(renames: ImageRename[]): Promise<{
+  succeeded: ImageRename[];
+  failed: Array<{ rename: ImageRename; error: string }>;
+}> {
+  const succeeded: ImageRename[] = [];
+  const failed: Array<{ rename: ImageRename; error: string }> = [];
+
+  for (const rename of renames) {
+    try {
+      const sourceUri = vscode.Uri.file(rename.oldAbsolute);
+      const targetUri = vscode.Uri.file(rename.newAbsolute);
+
+      // Check if target exists
+      try {
+        await vscode.workspace.fs.stat(targetUri);
+        // Target exists - ask user
+        const action = await vscode.window.showWarningMessage(
+          `File "${path.basename(rename.newAbsolute)}" already exists.`,
+          "Overwrite",
+          "Skip",
+        );
+        if (action !== "Overwrite") {
+          failed.push({ rename, error: "Skipped - target exists" });
+          continue;
+        }
+      } catch {
+        // Target doesn't exist - OK to proceed
+      }
+
+      // Execute rename
+      await vscode.workspace.fs.rename(sourceUri, targetUri, { overwrite: true });
+      succeeded.push(rename);
+    } catch (err) {
+      failed.push({
+        rename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { succeeded, failed };
+}
+
+/**
+ * Update image references in all markdown files within workspace.
+ */
+export async function updateWorkspaceReferences(
+  renames: ImageRename[],
+  excludeUri?: vscode.Uri,
+): Promise<number> {
+  const mdFiles = await vscode.workspace.findFiles(
+    "**/*.md",
+    "**/node_modules/**",
+  );
+  let updatedCount = 0;
+
+  for (const fileUri of mdFiles) {
+    // Skip current document (already has new paths)
+    if (excludeUri && fileUri.toString() === excludeUri.toString()) continue;
+
+    try {
+      const content = await vscode.workspace.fs.readFile(fileUri);
+      let text = Buffer.from(content).toString("utf8");
+      let modified = false;
+
+      for (const rename of renames) {
+        const oldRef = rename.oldRelative;
+        const newRef = rename.newRelative;
+
+        if (text.includes(oldRef)) {
+          text = text.split(oldRef).join(newRef);
+          modified = true;
+        }
+      }
+
+      if (modified) {
+        await vscode.workspace.fs.writeFile(fileUri, Buffer.from(text, "utf8"));
+        updatedCount++;
+      }
+    } catch (err) {
+      console.error(`[Image Rename] Failed to update ${fileUri.fsPath}:`, err);
+    }
+  }
+
+  return updatedCount;
 }

--- a/src/webview/frontmatter.ts
+++ b/src/webview/frontmatter.ts
@@ -74,9 +74,10 @@ export function parseContent(markdown: string): ParsedContent {
  */
 export function reconstructContent(
   frontmatter: string | null,
-  body: string
+  body: unknown
 ): string {
-  const safeBody = body ?? "";
+  // Validate body parameter - ensure it's a string
+  const safeBody = typeof body === "string" ? body : String(body ?? "");
   if (frontmatter === null || frontmatter.trim() === "") {
     return safeBody;
   }

--- a/src/webview/image-edit-plugin.ts
+++ b/src/webview/image-edit-plugin.ts
@@ -1,0 +1,444 @@
+import type { EditorView } from "@milkdown/kit/prose/view";
+
+/**
+ * Floating overlay for editing image URLs.
+ * Uses a separate overlay element to avoid interfering with Milkdown's DOM.
+ */
+
+// Pencil SVG icon
+const EDIT_ICON_SVG = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`;
+
+// Callback types
+type EditCallback = (newUrl: string, originalPath: string) => void;
+const pendingEdits = new Map<string, { callback: EditCallback; originalPath: string }>();
+
+// Pending rename operations (rename file before updating editor)
+interface PendingRename {
+  nodePos: number;
+  nodeAttrs: Record<string, unknown>;
+}
+const pendingRenames = new Map<string, PendingRename>();
+
+// Store references
+let storedGetView: (() => EditorView | null) | null = null;
+let storedPostMessage: ((msg: unknown) => void) | null = null;
+let currentImageMap: Record<string, string> = {};
+
+// Overlay elements
+let overlayContainer: HTMLDivElement | null = null;
+let currentHoveredImg: HTMLImageElement | null = null;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+let storedEditorEl: HTMLElement | null = null;
+
+// Track mouse position for detecting hover on newly added images
+let lastMouseX = 0;
+let lastMouseY = 0;
+
+/**
+ * Check if a point is inside an element's bounding rect
+ */
+function isPointInElement(x: number, y: number, el: Element): boolean {
+  const rect = el.getBoundingClientRect();
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
+/**
+ * Create the floating overlay container
+ * Appends to parent of editorEl (container) to survive Crepe recreation
+ */
+function createOverlay(editorEl: HTMLElement): HTMLDivElement {
+  const overlay = document.createElement("div");
+  overlay.className = "image-edit-overlay";
+  overlay.innerHTML = `<button class="image-edit-btn" title="Edit image path">${EDIT_ICON_SVG}</button>`;
+
+  const btn = overlay.querySelector(".image-edit-btn") as HTMLButtonElement;
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (currentHoveredImg) {
+      triggerImageEdit(currentHoveredImg);
+    }
+  });
+
+  // Append to parent (container) instead of editorEl to survive Crepe recreation
+  const container = editorEl.parentElement;
+  if (container) {
+    container.appendChild(overlay);
+  } else {
+    editorEl.appendChild(overlay);
+  }
+  return overlay;
+}
+
+/**
+ * Position overlay relative to image (accounts for scroll)
+ * Uses left instead of right for consistent positioning across hover states
+ */
+function positionOverlay(img: HTMLImageElement): void {
+  if (!overlayContainer || !storedEditorEl) return;
+
+  // Get container (where overlay is appended) for positioning reference
+  const container = overlayContainer.parentElement;
+  if (!container) return;
+
+  const imgRect = img.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+
+  // Position at top-right of image, relative to container
+  // Use left positioning (imgRect.right - button width offset) for consistency
+  const top = imgRect.top - containerRect.top + container.scrollTop + 12;
+  const left = imgRect.right - containerRect.left - 48 - 32; // 36 offset + 32 button width
+
+  // Clear right property and set left for consistent positioning
+  overlayContainer.style.right = "";
+  overlayContainer.style.top = `${top}px`;
+  overlayContainer.style.left = `${left}px`;
+  overlayContainer.classList.add("visible");
+}
+
+/**
+ * Show overlay for image, cancel any pending hide
+ */
+function showOverlay(img: HTMLImageElement): void {
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  currentHoveredImg = img;
+  positionOverlay(img);
+}
+
+/**
+ * Hide overlay immediately (CSS handles fade animation)
+ */
+function hideOverlay(): void {
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  if (overlayContainer) {
+    overlayContainer.classList.remove("visible");
+  }
+  currentHoveredImg = null;
+}
+
+/**
+ * Setup hover listeners for images
+ */
+export function setupImageEditOverlay(
+  editorEl: HTMLElement,
+  getView: () => EditorView | null,
+  postMessage: (msg: unknown) => void
+): void {
+  storedGetView = getView;
+  storedPostMessage = postMessage;
+  storedEditorEl = editorEl;
+  overlayContainer = createOverlay(editorEl);
+
+  // Use mousemove with bounding rect check for reliable hover detection
+  // (Milkdown wraps images in containers, so direct target check doesn't work)
+  editorEl.addEventListener("mousemove", (e) => {
+    lastMouseX = e.clientX;
+    lastMouseY = e.clientY;
+
+    // Find img element under mouse position
+    const images = Array.from(editorEl.querySelectorAll("img"));
+    let foundImg: HTMLImageElement | null = null;
+    for (const img of images) {
+      if (isPointInElement(e.clientX, e.clientY, img)) {
+        foundImg = img;
+        break;
+      }
+    }
+
+    if (foundImg) {
+      // Mouse is over an image - show overlay
+      if (currentHoveredImg !== foundImg) {
+        showOverlay(foundImg);
+      } else if (hideTimer) {
+        // Cancel pending hide if still on same image
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    } else if (currentHoveredImg && !overlayContainer?.contains(e.target as Node)) {
+      // Mouse left image area (and not on overlay) - schedule hide
+      hideOverlay();
+    }
+  });
+
+  editorEl.addEventListener("mouseleave", (e) => {
+    const relatedTarget = e.relatedTarget as HTMLElement | null;
+    // Don't hide if moving to overlay
+    if (relatedTarget && overlayContainer?.contains(relatedTarget)) return;
+    hideOverlay();
+  });
+
+  // Overlay hover: cancel hide timer, schedule hide on leave
+  overlayContainer.addEventListener("mouseenter", () => {
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  });
+
+  overlayContainer.addEventListener("mouseleave", () => {
+    hideOverlay();
+  });
+
+  // Double-click on image also triggers edit
+  editorEl.addEventListener("dblclick", (e) => {
+    const target = e.target as HTMLElement;
+    // Find <img> element: could be target itself, inside target (wrapper), or ancestor
+    let img: HTMLImageElement | null = null;
+    if (target.tagName === "IMG") {
+      img = target as HTMLImageElement;
+    } else {
+      // Check if <img> is inside target (e.g., image-wrapper contains img)
+      img = target.querySelector("img");
+      // Fallback: check if target is inside an image container
+      if (!img) {
+        const wrapper = target.closest(".image-wrapper, .image-block");
+        if (wrapper) {
+          img = wrapper.querySelector("img");
+        }
+      }
+    }
+    if (img) {
+      e.preventDefault();
+      e.stopPropagation();
+      triggerImageEdit(img);
+    }
+  }, true);
+
+  // Watch for newly added images (e.g., after paste) and show overlay if mouse is over them
+  const observer = new MutationObserver(() => {
+    // Delay to let Milkdown finish rendering
+    setTimeout(() => {
+      const images = Array.from(editorEl.querySelectorAll("img"));
+      for (const img of images) {
+        if (isPointInElement(lastMouseX, lastMouseY, img)) {
+          showOverlay(img);
+          break;
+        }
+      }
+    }, 150);
+  });
+  observer.observe(editorEl, { childList: true, subtree: true });
+}
+
+/**
+ * Trigger image URL edit
+ */
+function triggerImageEdit(imgEl: HTMLImageElement): void {
+  if (!storedGetView || !storedPostMessage) return;
+
+  const view = storedGetView();
+  if (!view) return;
+
+  const nodeInfo = findImageNode(view, imgEl);
+  if (!nodeInfo) return;
+
+  const { node, nodePos } = nodeInfo;
+  const currentSrc = String(node.attrs.src || "");
+
+  requestUrlEdit(currentSrc, storedPostMessage, (newUrl, originalPath) => {
+    const pathToCompare = originalPath || currentSrc;
+    if (newUrl && newUrl !== pathToCompare) {
+      // Check if this is a local image rename (same folder, different filename)
+      const isLocalRename = !newUrl.startsWith("http") && !newUrl.startsWith("data:")
+        && originalPath && !originalPath.startsWith("http")
+        && getFolder(originalPath) === getFolder(newUrl);
+
+      if (isLocalRename && storedPostMessage) {
+        // Request rename FIRST, then update editor after file is renamed
+        const renameId = `rename-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        pendingRenames.set(renameId, { nodePos, nodeAttrs: { ...node.attrs } });
+
+        storedPostMessage({
+          type: "requestImageRename",
+          renameId,
+          oldPath: originalPath,
+          newPath: newUrl,
+        });
+
+        // Timeout cleanup: Remove from pending after 60s to prevent memory leak
+        setTimeout(() => {
+          if (pendingRenames.has(renameId)) {
+            console.warn("[ImageEdit] Rename timeout, cleaning up:", renameId);
+            pendingRenames.delete(renameId);
+          }
+        }, 60000);
+      } else {
+        // Non-local or URL change: update editor immediately
+        updateEditorNode(nodePos, node.attrs, newUrl);
+      }
+    }
+  });
+}
+
+/** Get folder part of path */
+function getFolder(p: string): string {
+  const lastSlash = p.lastIndexOf("/");
+  return lastSlash > 0 ? p.substring(0, lastSlash) : "";
+}
+
+/** Update ProseMirror node with new src */
+function updateEditorNode(nodePos: number, attrs: Record<string, unknown>, newSrc: string): void {
+  const freshView = storedGetView?.();
+  if (!freshView) return;
+
+  const { state, dispatch } = freshView;
+  const tr = state.tr.setNodeMarkup(nodePos, undefined, {
+    ...attrs,
+    src: newSrc,
+  });
+  dispatch(tr);
+}
+
+// Node types that represent images
+const IMAGE_NODE_TYPES = ["image-block", "image", "image-inline"];
+
+interface NodeInfo {
+  node: { type: { name: string }; attrs: Record<string, unknown> };
+  nodePos: number;
+}
+
+/**
+ * Find image node from DOM element
+ */
+function findImageNode(view: EditorView, imgEl: Element): NodeInfo | null {
+  try {
+    const pos = view.posAtDOM(imgEl, 0);
+    const { state } = view;
+
+    for (let offset = 0; offset <= 10; offset++) {
+      for (const tryPos of [pos - offset, pos + offset]) {
+        if (tryPos < 0 || tryPos > state.doc.content.size) continue;
+
+        const $pos = state.doc.resolve(tryPos);
+        let node = $pos.nodeAfter;
+        let nodePos = tryPos;
+
+        if (!node || !IMAGE_NODE_TYPES.includes(node.type.name)) {
+          if (IMAGE_NODE_TYPES.includes($pos.parent.type.name)) {
+            node = $pos.parent;
+            nodePos = $pos.before();
+          }
+        }
+
+        if (node && IMAGE_NODE_TYPES.includes(node.type.name)) {
+          return { node, nodePos };
+        }
+      }
+    }
+  } catch (err) {
+    console.error("[ImageEdit] Failed to find node:", err);
+  }
+  return null;
+}
+
+export function setImageMap(imageMap: Record<string, string>): void {
+  currentImageMap = imageMap;
+}
+
+/**
+ * Request URL edit via VSCode extension
+ */
+function requestUrlEdit(
+  currentUrl: string,
+  postMessage: (msg: unknown) => void,
+  onResult: EditCallback
+): void {
+  const editId = `edit-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const isBase64 = currentUrl.startsWith("data:");
+  const isLocalImage = currentUrl.startsWith("vscode-webview://")
+    || currentUrl.includes("vscode-resource.vscode-cdn.net");
+
+  let displayUrl = currentUrl;
+  if (isBase64) {
+    displayUrl = "";
+  } else if (isLocalImage) {
+    // Reverse lookup from imageMap
+    for (const [originalPath, webviewUri] of Object.entries(currentImageMap)) {
+      if (webviewUri === currentUrl) {
+        displayUrl = originalPath;
+        break;
+      }
+    }
+  }
+
+  pendingEdits.set(editId, { callback: onResult, originalPath: displayUrl });
+
+  postMessage({
+    type: "requestImageUrlEdit",
+    editId,
+    currentUrl: displayUrl,
+    isLocalImage,
+    isBase64,
+  });
+
+  setTimeout(() => pendingEdits.delete(editId), 60000);
+}
+
+/**
+ * Handle URL edit response from extension
+ */
+export function handleUrlEditResponse(editId: string, newUrl: string | null): void {
+  const pending = pendingEdits.get(editId);
+  if (pending && newUrl !== null && newUrl.trim() !== "") {
+    const cleanedUrl = cleanImagePathInput(newUrl);
+    pending.callback(cleanedUrl, pending.originalPath);
+  }
+  pendingEdits.delete(editId);
+}
+
+/**
+ * Handle image rename response from extension
+ * Called AFTER file has been renamed on disk
+ */
+export function handleImageRenameResponse(
+  renameId: string,
+  success: boolean,
+  newPath: string,
+  webviewUri?: string
+): void {
+  const pending = pendingRenames.get(renameId);
+  if (!pending) return;
+  pendingRenames.delete(renameId);
+
+  if (success && webviewUri) {
+    // Update imageMap BEFORE updating editor so transformForSave works correctly
+    // This ensures webviewUri gets converted back to relative path when saving
+    currentImageMap[newPath] = webviewUri;
+
+    // Now update editor with webviewUri for display
+    updateEditorNode(pending.nodePos, pending.nodeAttrs, webviewUri);
+  } else if (success) {
+    // No webviewUri - use newPath directly
+    updateEditorNode(pending.nodePos, pending.nodeAttrs, newPath);
+  }
+  // If failed, don't update editor (keep old path)
+}
+
+/**
+ * Clean image path input
+ */
+function cleanImagePathInput(rawInput: string): string {
+  let p = rawInput.trim();
+
+  if (p.startsWith("<")) {
+    const endBracket = p.indexOf(">");
+    if (endBracket !== -1) {
+      p = p.slice(1, endBracket);
+    }
+    return p.trim();
+  }
+
+  const titleSeparator = p.search(/\s+["']/);
+  if (titleSeparator !== -1) {
+    p = p.slice(0, titleSeparator);
+  }
+
+  return p.trim();
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -708,14 +708,13 @@ window.addEventListener("message", async (event) => {
     case "update":
       if (typeof message.content === "string") {
         const newImageMap = message.imageMap || {};
-        const imageMapChanged =
-          JSON.stringify(newImageMap) !== JSON.stringify(currentImageMap);
         currentImageMap = newImageMap;
         setImageMap(newImageMap);
 
-        // Skip content update if echo AND imageMap unchanged
-        // (force update when new images were saved to refresh display)
-        if (message.content === lastSentContent && !imageMapChanged) {
+        // Skip content update if this is echo from our edit
+        // Editor already has correct content, just update imageMap
+        // (imageMap changes on delete don't require recreate)
+        if (message.content === lastSentContent) {
           lastSentContent = null;
           break;
         }


### PR DESCRIPTION
## Summary

- Implement complete image upload workflow: paste from clipboard or use file picker
- Add image URL editing with double-click support and VSCode input dialog
- Implement automatic image renaming when paths change in markdown (same folder)
- Implement automatic image deletion when images are removed from markdown (moves to Trash)
- Improve overlay hover detection for Milkdown image blocks to show edit icon
- Fix cursor position loss when deleting images by preventing editor recreation

## Test plan

- [ ] Paste image from clipboard into editor
- [ ] Upload image via file picker button
- [ ] Verify images save to configured folder and display correctly
- [ ] Double-click on image to edit URL/path
- [ ] Change image filename in markdown and confirm auto-rename works
- [ ] Remove image from markdown and confirm auto-delete works
- [ ] Verify cursor position maintains when deleting images
- [ ] Test with various image path formats (relative, absolute, workspace-root)
- [ ] Verify settings work: imageSaveFolder, autoRenameImages, autoDeleteImages
- [ ] Build extension and package as .vsix file