### PR TITLE
fix: resolve editor initialization loop (v1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,27 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.5.2] - 2026-01-27
+
+### Fixed
+
+* **Editor Initialization Loop**
+  * Fixed editor recreating 15+ times on document load (echo loop prevention)
+  * Track content + imageMap keys together to detect echo from edits
+  * Debounce `updateWebview()` calls (50ms) to prevent rapid updates
+  * Guard `editorViewCtx` access to avoid "Context not found" errors
+  * Cancel pending debounced edits when destroying editor
+
 ## \[1.5.1] - 2026-01-25
 
 ### Added
 
 * **Heading Level Indicator**
+
   * Displays H1-H6 badges next to headings for quick level identification
+
   * Subtle styling with muted colors
+
   * Supports all 10 themes (light and dark)
 
 ## \[1.5.0] - 2026-01-24
@@ -16,38 +30,61 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Added
 
 * **Auto-link Paste URL**
+
   * When text is selected and you paste a URL, automatically converts to markdown link `[selected text](url)`
+
   * Supports http/https URLs only
+
   * Replaces existing link URL if selection is already a link
+
   * Intelligently skips paste events with files (images handled by image upload)
 
 * **Image Upload & Paste Support**
+
   * Paste images from clipboard directly into the editor
+
   * Upload images via Crepe's file picker button
+
   * Images saved automatically to configurable folder
+
   * Configurable via `tuiMarkdown.imageSaveFolder` setting (default: `images`)
+
   * Use `.` for same folder as document
 
 * **Local Image Display**
+
   * Renders local images from document folder and workspace
+
   * Supports both relative and absolute paths
+
   * Automatic path resolution for webview display
 
 * **Image URL Editing**
+
   * Hover on image to show edit icon (pencil button)
+
   * Double-click on image to edit URL/path via VSCode input box
+
   * Shows original path instead of webview URI
 
 * **Auto Rename Images**
+
   * Automatically rename image files when you change the path in Markdown
+
   * Only triggers when image folder remains the same
+
   * Updates all references in workspace `.md` files
+
   * Configurable via `tuiMarkdown.autoRenameImages` setting (default: true)
 
 * **Auto Delete Images**
+
   * Automatically delete image files when removed from markdown
+
   * Moves files to Trash (recoverable)
+
   * Shows warning if image is used in other `.md` files
+
   * Configurable via `tuiMarkdown.autoDeleteImages` setting (default: true)
 
 ### Fixed
@@ -57,6 +94,7 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Changed
 
 * Image edit icon now shows when hovering anywhere on image block (not just the image itself)
+
 * Extended `localResourceRoots` to include document folder and workspace for image loading
 
 ## \[1.4.0] - 2026-01-24
@@ -64,9 +102,13 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Added
 
 * Catppuccin theme palette with 4 variants
+
   * Catppuccin Latte (light)
+
   * Catppuccin Frappé (dark, subdued)
+
   * Catppuccin Macchiato (dark, medium contrast)
+
   * Catppuccin Mocha (dark, original)
 
 ## \[1.3.1] - 2026-01-24
@@ -74,8 +116,11 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Added
 
 * Table auto-width CSS for proportional column sizing
+
   * Columns size automatically based on content
+
   * Table spans full editor width
+
   * Cell text wraps naturally for responsive display
 
 ## \[1.3.0] - 2026-01-24
@@ -83,13 +128,19 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 ### Added
 
 * Cursor line highlight with theme support
+
   * Highlights current block/paragraph containing cursor
+
   * Individual list item highlighting (not entire list)
+
   * Skips code blocks (they have built-in highlighting)
+
   * Configurable via `tuiMarkdown.highlightCurrentLine` setting
 
 * Responsive max-width layout (1200px) for editor content on large screens
+
   * Improves readability on 4K/ultrawide monitors
+
   * Full-width on screens ≤1200px (split view compatible)
 
 * Collapsible metadata panel for editing YAML frontmatter
@@ -153,3 +204,4 @@ All notable changes to "Milkdown Markdown WYSIWYG" extension.
 * Configurable font size (8-32px)
 
 * Support for .md and .markdown files
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "Milkdown Markdown WYSIWYG",
   "description": "A beautiful WYSIWYG Markdown editor powered by Milkdown Crepe. Edit markdown files with rich text experience and theme selection.",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- Fix editor recreating 15+ times on document load (echo loop prevention)
- Track content + imageMap keys together to detect echo from edits
- Debounce `updateWebview()` calls (50ms) to prevent rapid updates
- Guard `editorViewCtx` access to avoid "Context not found" errors
- Cancel pending debounced edits when destroying editor

## Test plan
- [ ] Open `.md` file with images - verify single "Starting initialization..." log
- [ ] Edit text → save → verify no editor recreation
- [ ] Paste image → verify no "editorView not found" error