### PR TITLE
fix: improve diff view compatibility with vscode-scm scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.5.3] - 2026-02-04
+
+### Fixed
+
+* **Diff View Compatibility**
+  * Added `vscode-scm` URI scheme to editor associations
+  * Improves reliability when viewing markdown diffs in Source Control panel
+  * Addresses intermittent issue where WYSIWYG editor opened instead of text diff
+
 ## \[1.5.2] - 2026-01-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "Milkdown Markdown WYSIWYG",
   "description": "A beautiful WYSIWYG Markdown editor powered by Milkdown Crepe. Edit markdown files with rich text experience and theme selection.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",
@@ -123,8 +123,8 @@
     ],
     "configurationDefaults": {
       "workbench.editorAssociations": {
-        "{git,gitlens}:/**/*.md": "default",
-        "{git,gitlens}:/**/*.markdown": "default"
+        "{git,gitlens,vscode-scm}:/**/*.md": "default",
+        "{git,gitlens,vscode-scm}:/**/*.markdown": "default"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Added `vscode-scm` URI scheme to `configurationDefaults.workbench.editorAssociations`
- Fixes intermittent issue where WYSIWYG editor opened instead of text diff in Source Control panel
- Version bump to 1.5.3

## Test plan
- [ ] Open a `.md` file with uncommitted changes
- [ ] Click on the file in Source Control panel → should show text diff, not WYSIWYG editor
- [ ] Use GitLens inline diff → should show text diff
- [ ] Normal `.md` file open → should still use Milkdown WYSIWYG editor