### PR TITLE
fix: resolve editor initialization and hardbreak rendering issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,42 @@
 
 All notable changes to "Milkdown Markdown WYSIWYG" extension.
 
+## \[1.5.5] - 2026-02-06
+
+### Fixed
+
+* **Inline Hardbreak Rendering**
+
+  * Single newlines (soft breaks) now display as visual line breaks instead of inline spaces
+
+  * Added CSS to collapse inline hardbreak `<span>` elements into block-level breaks
+
+* **Concurrent Editor Initialization**
+
+  * Added `isEditorInitializing` guard to prevent overlapping editor init/recreate calls
+
+  * Flush microtasks between destroy and create to avoid stale state
+
+  * Skip `update` messages while editor is still initializing
+
+* **CSP Font Source**
+
+  * Added `data:` to `font-src` CSP directive to support data URI fonts
+
 ## \[1.5.2] - 2026-01-27
 
 ### Fixed
 
 * **Editor Initialization Loop**
+
   * Fixed editor recreating 15+ times on document load (echo loop prevention)
+
   * Track content + imageMap keys together to detect echo from edits
+
   * Debounce `updateWebview()` calls (50ms) to prevent rapid updates
+
   * Guard `editorViewCtx` access to avoid "Context not found" errors
+
   * Cancel pending debounced edits when destroying editor
 
 ## \[1.5.1] - 2026-01-25

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -756,7 +756,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       img-src ${webview.cspSource} https: data:;
       script-src 'nonce-${nonce}';
       style-src ${webview.cspSource} 'unsafe-inline';
-      font-src ${webview.cspSource};
+      font-src ${webview.cspSource} data:;
       connect-src 'none';
     `
       .replace(/\s+/g, " ")
@@ -1123,6 +1123,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           body.theme-catppuccin-macchiato .heading-level-badge,
           body.theme-catppuccin-mocha .heading-level-badge {
             color: rgba(255, 255, 255, 0.5);
+          }
+
+          /* Render inline hardbreaks (soft breaks) as visual line breaks.
+             Milkdown renders isInline:true hardbreaks as <span> with a space,
+             but users expect single newlines to display as line breaks. */
+          .milkdown .ProseMirror span[data-type="hardbreak"][data-is-inline="true"] {
+            display: block;
+            height: 0;
+            overflow: hidden;
           }
 
         </style>


### PR DESCRIPTION
Fixes multiple stability issues in v1.5.5:

- Add guard to prevent concurrent editor init/recreate calls using isEditorInitializing flag
- Flush microtasks between destroy and create to avoid stale editor state
- Skip update messages while editor is initializing to prevent loops
- Add data: to font-src CSP directive for data URI font support
- Add CSS to render inline hardbreak elements as visual line breaks instead of spaces

Closes issues with editor recreating multiple times on load and soft breaks not displaying correctly.