### PR TITLE
fix: improve blank line roundtrip with space token parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to "TUI Markdown Editor" extension.
 
 ### Changed
 
-* **Empty line serialization**: Empty paragraphs now serialize as `<br>` instead of `&nbsp;` in markdown output for better consistency and readability
+* **Blank line roundtrip**: Empty paragraphs now roundtrip via MarkedJS `space` token parsing (`BlankLineHandler`) and custom `Document` serializer, replacing the `<br>` hack + `convertBrOnlyParagraphsToEmpty` post-parse step
 
 * **Editor Engine Migration: Milkdown Crepe -> Tiptap**
 
@@ -96,6 +96,8 @@ All notable changes to "TUI Markdown Editor" extension.
 * Removed `@milkdown/crepe` and `sharp` dependencies
 
 * Removed `paste-link-plugin.ts` (replaced by built-in Link extension)
+
+* Removed `convertBrOnlyParagraphsToEmpty` post-parse step (replaced by `BlankLineHandler` extension)
 
 * Removed Milkdown-specific hardbreak rendering CSS hack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 **Content updates:** `editor.commands.setContent()` - no destroy/recreate needed. Cursor position preserved via save/restore around setContent.
 
-**Empty paragraph serialization:** Empty paragraphs serialize as `<br>` (not `&nbsp;`). Custom `Paragraph.extend()` overrides `renderMarkdown`. Post-parse step `convertBrOnlyParagraphsToEmpty()` converts paragraph-with-only-hardBreak back to empty paragraphs for stable roundtrip.
+**Empty paragraph roundtrip:** `BlankLineHandler` extension parses MarkedJS `space` tokens into empty paragraph nodes (count = newlines - 2). Custom `Document.extend({ renderMarkdown })` serializes empty paragraphs as single `\n` (instead of `\n\n`), producing correct blank line count in markdown output.
 
 **Node naming:** Tiptap uses camelCase: `listItem`, `codeBlock`, `taskList`, `taskItem`, `tableCell`, `tableHeader`.
 

--- a/docs/tiptap-markdown-reference.md
+++ b/docs/tiptap-markdown-reference.md
@@ -2,7 +2,7 @@
 
 > Package: `@tiptap/markdown` (Beta)
 > Parser: MarkedJS (CommonMark compliant, extensible)
-> Source: <https://tiptap.dev/docs/editor/markdown>
+> Source: [https://tiptap.dev/docs/editor/markdown](https://tiptap.dev/docs/editor/markdown)
 
 ## Architecture
 
@@ -13,15 +13,13 @@ Parsing:   Markdown String → MarkedJS Lexer (Tokenization) → Markdown Tokens
 Serialize: Tiptap JSON → Extension Render Handlers → Markdown String
 ```
 
-* Tokenizer: scans raw markdown, produces tokens
-
-* Lexer: orchestrates tokenizers sequentially, manages MarkedJS instance
-
-* Token: plain JS object `{ type, raw, text, tokens?, ... }`
-
-* Tiptap JSON: `{ type, attrs?, content?, text?, marks? }` - native ProseMirror format
+- Tokenizer: scans raw markdown, produces tokens
+- Lexer: orchestrates tokenizers sequentially, manages MarkedJS instance
+- Token: plain JS object `{ type, raw, text, tokens?, ... }`
+- Tiptap JSON: `{ type, attrs?, content?, text?, marks? }` - native ProseMirror format
 
 ### Key Concepts
+
 
 | Term        | Description                                                                          |
 | ----------- | ------------------------------------------------------------------------------------ |
@@ -29,6 +27,7 @@ Serialize: Tiptap JSON → Extension Render Handlers → Markdown String
 | Tiptap JSON | ProseMirror document format with nodes (block) and marks (inline)                    |
 | Tokenizer   | Functions that scan markdown text → tokens                                           |
 | Lexer       | Orchestrator applying tokenizers to produce complete token list                      |
+
 
 ## Installation & Setup
 
@@ -480,19 +479,18 @@ export const Callout = Node.create({
 
 ## Tokenizer Best Practices
 
-1. **Always anchor regex with** **`^`** - match from string start only
-2. **Return** **`undefined`** **on no match** - essential for fallback
-3. **Include** **`raw`** **property** - must contain full matched string
+1. **Always anchor regex with** `**^**` - match from string start only
+2. **Return** `**undefined**` **on no match** - essential for fallback
+3. **Include** `**raw**` **property** - must contain full matched string
 4. **Use non-greedy quantifiers** - `+?` and `*?` over greedy
-5. **Use** **`start()`** **optimization** - skip irrelevant text portions
+5. **Use** `**start()**` **optimization** - skip irrelevant text portions
 6. **Use correct lexer method** - `lexer.inlineTokens()` for inline, `lexer.blockTokens()` for blocks
 7. **Test edge cases** - empty content, nesting, unclosed syntax
 
 ## Limitations
 
-* Comments unsupported (lost during markdown content replacement)
+- Comments unsupported (lost during markdown content replacement)
+- Table cells allow only one child node (markdown syntax constraint)
+- Beta status - API may change
 
-* Table cells allow only one child node (markdown syntax constraint)
-
-* Beta status - API may change
-
+<br>

--- a/src/webview/table-markdown-serializer.ts
+++ b/src/webview/table-markdown-serializer.ts
@@ -143,7 +143,7 @@ export function renderTableToMarkdown(node: JSONContent, h: MarkdownRendererHelp
   const headerRow = rows[0];
   const hasHeader = headerRow?.some(c => c.isHeader) ?? false;
 
-  let out = '\n';
+  let out = '';
 
   // Header row
   const headerTexts = Array.from({ length: colCount }, (_, i) =>


### PR DESCRIPTION
## Summary
- Replace `<br>` hack + `convertBrOnlyParagraphsToEmpty` post-parse step with `BlankLineHandler` extension (parses MarkedJS `space` tokens into empty paragraph nodes)
- Add custom `Document.extend({ renderMarkdown })` serializer that emits single `\n` for empty paragraphs (instead of `\n\n` separator)
- Remove leading `\n` from table serializer output to avoid extra blank lines with new Document serializer

## Test plan
- [ ] Open markdown file with multiple blank lines between paragraphs → verify blank lines preserved in editor
- [ ] Type text, add blank lines, save → verify markdown output has correct blank line count
- [ ] Roundtrip test: open file → no edits → save → diff should be empty
- [ ] Table rendering: verify no extra blank line before tables in output
- [ ] Edge cases: consecutive blank lines (2+), blank lines at start/end of doc