### PR TITLE
v2.1.0: Full-width editor layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -804,7 +804,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             --heading-h4-margin-bottom: 8px;
             --heading-h5-margin-bottom: 6px;
             --heading-h6-margin-bottom: 6px;
-            --content-max-width: 760px;
+            --content-max-width: 100%;
           }
           * { box-sizing: border-box; }
           html, body {
@@ -1141,22 +1141,16 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           #metadata-details.hidden { display: none; }
           #table-context.hidden { display: none; }
 
-          /* Responsive editor content — adaptive width */
+          /* Full-width editor with comfortable padding */
           .tiptap {
-            max-width: var(--content-max-width, 760px);
-            margin-left: auto;
-            margin-right: auto;
+            max-width: 100%;
+            padding-left: 64px;
+            padding-right: 64px;
           }
           @media (max-width: 900px) {
             .tiptap {
-              max-width: 100%;
               padding-left: 24px;
               padding-right: 24px;
-            }
-          }
-          @media (min-width: 901px) and (max-width: 1200px) {
-            .tiptap {
-              max-width: min(85vw, 760px);
             }
           }
           /* Tables can overflow content width */


### PR DESCRIPTION
## Summary
- Remove fixed `max-width: 760px` constraint — editor content now fills available width
- Add comfortable padding: 64px (desktop), 24px (mobile ≤900px)
- Bump version to 2.1.0

## Test plan
- [ ] Open a markdown file in the editor, verify content spans full width
- [ ] Resize window to < 900px, verify padding shrinks to 24px
- [ ] Check tables still overflow correctly