### PR TITLE
fix: task list nested layout broken by CSS descendant selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to "TUI Markdown Editor" extension.
 
 * **Table of Contents Sidebar**: Toggleable TOC panel inside the editor with click-to-scroll navigation, active heading highlight, H1-H6 depth filter, collapse/expand sections, and state persistence
 
-* **Heading Collapse/Expand**: Visual-only toggle arrows on H1-H6 headings to collapse/expand content sections until next same-or-higher-level heading; state persisted across webview reloads
+* **Heading Collapse/Expand**: Visual-only toggle arrows on H1-H6 headings to collapse/expand content sections until next same-or-higher-level heading; hover heading badge to reveal toggle arrow; state persisted across webview reloads
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.3.1] - 2026-03-19
+
+### Fixed
+
+* **Task List Nested Layout**: Fixed `display: flex` leaking to nested list items inside task lists, causing paragraphs and code blocks to render side-by-side instead of vertically stacked. Changed CSS selectors from descendant to direct child combinator (`ul[data-type="taskList"] > li`)
+
 ## \[2.3.0] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to "TUI Markdown Editor" extension.
 
 * **Table of Contents Sidebar**: Toggleable TOC panel inside the editor with click-to-scroll navigation, active heading highlight, H1-H6 depth filter, collapse/expand sections, and state persistence
 
+* **Heading Collapse/Expand**: Visual-only toggle arrows on H1-H6 headings to collapse/expand content sections until next same-or-higher-level heading; state persisted across webview reloads
+
 ### Fixed
 
 * TOC button moved to right side of toolbar for better visibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 * Decoration-based: no schema changes, no markdown impact
 
-* **Toggle arrow**: `Decoration.widget` at `pos + 1` with `side: -1` (left of badge)
+* **Toggle arrow**: `Decoration.widget` at `pos + 1` with `side: -2` (renders before badge)
 
 * **Content hiding**: `Decoration.node` with `collapsed-content` class on section nodes below collapsed heading
 
@@ -378,19 +378,23 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 **CSS** (in `src/markdownEditorProvider.ts`):
 
-* Toggle arrow: `position: absolute; left: -32px` (left of heading), hidden by default, visible on hover/when collapsed
+* Toggle arrow overlaps heading-level-badge at same position (`left: -15px; top: 3px`), hidden by default (`opacity: 0`)
 
-* Arrow colors: light theme `rgba(0, 0, 0, 0.5)`, dark theme `rgba(255, 255, 255, 0.5)`
+* **Hover swap**: On heading hover, badge fades out (`opacity: 0`) and arrow fades in (`opacity: 0.6`) — click to toggle collapse
 
-* Arrow transition: 0.15s ease-out for opacity/background (respects `prefers-reduced-motion`)
+* **Collapsed state**: Arrow always visible, badge always hidden (via `.heading-collapsed-indicator` parent class)
+
+* Arrow colors: light `rgba(0, 0, 0, 0.5)`, dark `rgba(255, 255, 255, 0.5)`, `z-index: 2` above badge
 
 * Collapsed content: `display: none !important` to hide section nodes
 
-* Collapsed heading indicator: dashed border (1px, 0.15 opacity) to show hidden content exists
+* Collapsed heading indicator: dashed border (1px, 0.15 opacity)
+
+* `prefers-reduced-motion`: disables transitions
 
 **Coexistence**:
 
-* **Heading level badge**: Both add widgets at `pos + 1`, but use different `side` values (-1 for collapse arrow, 0+ for badge) — no conflict
+* **Heading level badge**: Both at `pos + 1`, same absolute position; CSS hover-swap mechanism — arrow has `z-index: 2` above badge
 
 * **TOC sidebar**: Independent heading extraction; TOC continues to track all headings (including hidden ones for state persistence)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ src/
     ├── frontmatter.ts        # YAML parsing & validation utilities
     ├── line-highlight-plugin.ts # ProseMirror plugin for cursor line highlight
     ├── heading-level-plugin.ts # ProseMirror plugin for H1-H6 level badges
+    ├── heading-collapse-plugin.ts # ProseMirror plugin for heading collapse/expand toggles
     ├── image-edit-plugin.ts  # Double-click image URL editing
     ├── table-markdown-serializer.ts # Custom GFM table serializer (multi-line cells)
     ├── table-cell-content-parser.ts # Post-parse transformer for table cell lists/breaks
@@ -346,6 +347,56 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 * Light themes: `rgba(0, 0, 0, 0.6)` (default)
 
 * Dark themes: `rgba(255, 255, 255, 0.5)` via `body.dark-theme` selector
+
+## Heading Collapse
+
+**Plugin** (`src/webview/heading-collapse-plugin.ts`):
+
+* ProseMirror plugin for visual-only heading collapse/expand toggles
+
+* Decoration-based: no schema changes, no markdown impact
+
+* **Toggle arrow**: `Decoration.widget` at `pos + 1` with `side: -1` (left of badge)
+
+* **Content hiding**: `Decoration.node` with `collapsed-content` class on section nodes below collapsed heading
+
+* **Stable heading keys**: `"H{level}:{text}:{occurrence}"` to survive position shifts; changes when heading text edited
+
+* **Section detection**: Collapses all nodes until next heading at same or higher level, or end of document
+
+* **State tracking**: `Map<string, boolean>` in plugin state for collapsed heading keys
+
+* **Click handler**: `handleDOMEvents.click` on toggle arrow to dispatch transaction with collapse meta
+
+**State Persistence** (in `src/webview/main.ts`):
+
+* Saved in `vscode.setState()` under `collapsedHeadings: string[]`
+
+* Restored after editor init via `setCollapsedHeadings()` helper
+
+* Updated on transaction via `onTransaction` hook when collapse meta present
+
+**CSS** (in `src/markdownEditorProvider.ts`):
+
+* Toggle arrow: `position: absolute; left: -32px` (left of heading), hidden by default, visible on hover/when collapsed
+
+* Arrow colors: light theme `rgba(0, 0, 0, 0.5)`, dark theme `rgba(255, 255, 255, 0.5)`
+
+* Arrow transition: 0.15s ease-out for opacity/background (respects `prefers-reduced-motion`)
+
+* Collapsed content: `display: none !important` to hide section nodes
+
+* Collapsed heading indicator: dashed border (1px, 0.15 opacity) to show hidden content exists
+
+**Coexistence**:
+
+* **Heading level badge**: Both add widgets at `pos + 1`, but use different `side` values (-1 for collapse arrow, 0+ for badge) — no conflict
+
+* **TOC sidebar**: Independent heading extraction; TOC continues to track all headings (including hidden ones for state persistence)
+
+* **Line highlight**: Won't highlight nodes with `display: none`
+
+* **Markdown output**: `editor.getMarkdown()` unaffected — decorations are visual-only
 
 ## TOC Sidebar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 **Empty paragraph roundtrip:** `BlankLineHandler` extension parses MarkedJS `space` tokens into empty paragraph nodes (count = newlines - 2). Custom `Document.extend({ renderMarkdown })` serializes empty paragraphs as single `\n` (instead of `\n\n`), producing correct blank line count in markdown output.
 
+**Task list CSS gotcha:** Task list selectors MUST use direct child combinator (`ul[data-type="taskList"] > li`) — descendant combinator leaks `display: flex` to nested regular list items, breaking vertical layout.
+
 **Node naming:** Tiptap uses camelCase: `listItem`, `codeBlock`, `taskList`, `taskItem`, `tableCell`, `tableHeader`.
 
 ## Metadata Panel

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -898,7 +898,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .tiptap h3,
           .tiptap h4,
           .tiptap h5,
-          .tiptap h6 { position: relative; text-wrap: balance; font-feature-settings: "liga" 0; }
+          .tiptap h6 { position: relative; font-feature-settings: "liga" 0; }
           .tiptap h1 { font-size: var(--heading-h1-size, 32px) !important; margin-top: var(--heading-h1-margin, 48px) !important; margin-bottom: var(--heading-h1-margin-bottom, 16px) !important; font-weight: 700; letter-spacing: -0.02em; line-height: 1.2; }
           .tiptap h2 { font-size: var(--heading-h2-size, 24px) !important; margin-top: var(--heading-h2-margin, 40px) !important; margin-bottom: var(--heading-h2-margin-bottom, 12px) !important; font-weight: 700; letter-spacing: -0.01em; line-height: 1.3; }
           .tiptap h3 { font-size: var(--heading-h3-size, 20px) !important; margin-top: var(--heading-h3-margin, 32px) !important; margin-bottom: var(--heading-h3-margin-bottom, 10px) !important; font-weight: 600; line-height: 1.4; }
@@ -1154,6 +1154,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               padding-right: 24px;
             }
           }
+          /* Table wrapper: horizontal scroll for wide tables */
+          .tiptap .tableWrapper {
+            overflow-x: auto;
+            max-width: 100%;
+          }
           /* Tables can overflow content width */
           .tiptap table {
             max-width: none;
@@ -1253,6 +1258,63 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           /* Dark themes (body.dark-theme set by applyTheme) */
           body.dark-theme .heading-level-badge {
             color: rgba(255, 255, 255, 0.5);
+          }
+
+          /* Heading collapse toggle arrow */
+          .heading-collapse-toggle {
+            position: absolute;
+            left: -32px;
+            top: 50%;
+            transform: translateY(-50%);
+            cursor: pointer;
+            font-size: 10px;
+            opacity: 0;
+            user-select: none;
+            padding: 2px 4px;
+            border-radius: 3px;
+            transition: opacity 0.15s ease-out, background 0.15s ease-out;
+            line-height: 1;
+            z-index: 1;
+            color: rgba(0, 0, 0, 0.5);
+          }
+          .tiptap h1:hover .heading-collapse-toggle,
+          .tiptap h2:hover .heading-collapse-toggle,
+          .tiptap h3:hover .heading-collapse-toggle,
+          .tiptap h4:hover .heading-collapse-toggle,
+          .tiptap h5:hover .heading-collapse-toggle,
+          .tiptap h6:hover .heading-collapse-toggle {
+            opacity: 0.6;
+          }
+          .heading-collapse-toggle.collapsed {
+            opacity: 0.6;
+          }
+          .heading-collapse-toggle:hover {
+            opacity: 1 !important;
+            background: rgba(0, 0, 0, 0.08);
+          }
+          body.dark-theme .heading-collapse-toggle {
+            color: rgba(255, 255, 255, 0.5);
+          }
+          body.dark-theme .heading-collapse-toggle:hover {
+            background: rgba(255, 255, 255, 0.1);
+          }
+          /* Hidden content under collapsed heading */
+          .collapsed-content {
+            display: none !important;
+          }
+          /* Dashed border on collapsed headings */
+          .heading-collapsed-indicator {
+            border-bottom: 1px dashed rgba(0, 0, 0, 0.15);
+            padding-bottom: 4px;
+            margin-bottom: 8px;
+          }
+          body.dark-theme .heading-collapsed-indicator {
+            border-bottom-color: rgba(255, 255, 255, 0.15);
+          }
+          @media (prefers-reduced-motion: reduce) {
+            .heading-collapse-toggle {
+              transition: none;
+            }
           }
 
           /* Base Tiptap editor styles */

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -862,26 +862,26 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             list-style: none;
             padding-left: 0;
           }
-          .tiptap ul[data-type="taskList"] li {
+          .tiptap ul[data-type="taskList"] > li {
             display: flex;
             align-items: flex-start;
             gap: calc(8px * var(--editor-font-scale, 1));
           }
-          .tiptap ul[data-type="taskList"] li > label {
+          .tiptap ul[data-type="taskList"] > li > label {
             flex-shrink: 0;
             margin-top: calc(4px * var(--editor-font-scale, 1));
             user-select: none;
           }
-          .tiptap ul[data-type="taskList"] li > label input[type="checkbox"] {
+          .tiptap ul[data-type="taskList"] > li > label input[type="checkbox"] {
             cursor: pointer;
             width: calc(16px * var(--editor-font-scale, 1));
             height: calc(16px * var(--editor-font-scale, 1));
             accent-color: var(--crepe-color-primary, var(--vscode-focusBorder));
           }
-          .tiptap ul[data-type="taskList"] li > div {
+          .tiptap ul[data-type="taskList"] > li > div {
             flex: 1;
           }
-          .tiptap ul[data-type="taskList"] li[data-checked="true"] > div p {
+          .tiptap ul[data-type="taskList"] > li[data-checked="true"] > div p {
             text-decoration: line-through;
             opacity: 0.5;
             transition: opacity 0.2s ease-out;

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1260,23 +1260,25 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             color: rgba(255, 255, 255, 0.5);
           }
 
-          /* Heading collapse toggle arrow */
+          /* Heading collapse toggle arrow — overlaps badge, shown on hover */
           .heading-collapse-toggle {
             position: absolute;
-            left: -32px;
-            top: 50%;
-            transform: translateY(-50%);
+            left: -15px;
+            top: 3px;
             cursor: pointer;
-            font-size: 10px;
+            font-size: 11px;
+            font-weight: 500;
             opacity: 0;
             user-select: none;
-            padding: 2px 4px;
+            padding: 0;
             border-radius: 3px;
-            transition: opacity 0.15s ease-out, background 0.15s ease-out;
+            transition: opacity 0.15s ease-out;
             line-height: 1;
-            z-index: 1;
+            z-index: 2;
             color: rgba(0, 0, 0, 0.5);
+            font-family: var(--vscode-editor-font-family, monospace);
           }
+          /* Hover heading: hide badge, show arrow */
           .tiptap h1:hover .heading-collapse-toggle,
           .tiptap h2:hover .heading-collapse-toggle,
           .tiptap h3:hover .heading-collapse-toggle,
@@ -1285,18 +1287,26 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .tiptap h6:hover .heading-collapse-toggle {
             opacity: 0.6;
           }
-          .heading-collapse-toggle.collapsed {
-            opacity: 0.6;
+          .tiptap h1:hover .heading-level-badge,
+          .tiptap h2:hover .heading-level-badge,
+          .tiptap h3:hover .heading-level-badge,
+          .tiptap h4:hover .heading-level-badge,
+          .tiptap h5:hover .heading-level-badge,
+          .tiptap h6:hover .heading-level-badge {
+            opacity: 0;
           }
           .heading-collapse-toggle:hover {
             opacity: 1 !important;
-            background: rgba(0, 0, 0, 0.08);
+          }
+          /* Collapsed state: always show arrow, always hide badge */
+          .heading-collapsed-indicator .heading-collapse-toggle {
+            opacity: 0.6;
+          }
+          .heading-collapsed-indicator .heading-level-badge {
+            opacity: 0 !important;
           }
           body.dark-theme .heading-collapse-toggle {
             color: rgba(255, 255, 255, 0.5);
-          }
-          body.dark-theme .heading-collapse-toggle:hover {
-            background: rgba(255, 255, 255, 0.1);
           }
           /* Hidden content under collapsed heading */
           .collapsed-content {

--- a/src/webview/heading-collapse-plugin.ts
+++ b/src/webview/heading-collapse-plugin.ts
@@ -1,0 +1,195 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet, EditorView } from "@tiptap/pm/view";
+import type { Node } from "@tiptap/pm/model";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+
+export const collapsePluginKey = new PluginKey("heading-collapse");
+
+interface CollapsePluginState {
+  collapsed: Set<string>;
+  headingKeys: Map<number, string>;
+  decorations: DecorationSet;
+}
+
+type CollapseMeta =
+  | { type: "toggle"; key: string }
+  | { type: "restore"; keys: string[] };
+
+/** Compute stable keys for headings: "H{level}:{text}:{occurrenceIndex}" */
+function computeHeadingKeys(doc: Node): Map<number, string> {
+  const posToKey = new Map<number, string>();
+  const seen = new Map<string, number>();
+  doc.descendants((node, pos) => {
+    if (node.type.name === "heading") {
+      const level = node.attrs.level as number;
+      const text = node.textContent || "(empty)";
+      const base = `H${level}:${text}`;
+      const idx = seen.get(base) || 0;
+      seen.set(base, idx + 1);
+      posToKey.set(pos, `${base}:${idx}`);
+    }
+  });
+  return posToKey;
+}
+
+/** Find the range of top-level nodes belonging to a heading's section. */
+function getSectionRange(
+  doc: Node,
+  headingPos: number,
+  headingLevel: number,
+): { from: number; to: number } | null {
+  let sectionStart = -1;
+  let sectionEnd = -1;
+  let pastHeading = false;
+
+  doc.forEach((node, offset) => {
+    if (sectionEnd !== -1) return; // already found boundary
+    if (offset === headingPos) {
+      pastHeading = true;
+      return;
+    }
+    if (!pastHeading) return;
+
+    if (sectionStart === -1) sectionStart = offset;
+
+    if (node.type.name === "heading" && (node.attrs.level as number) <= headingLevel) {
+      sectionEnd = offset;
+      return;
+    }
+  });
+
+  if (sectionStart === -1) return null;
+  if (sectionEnd === -1) sectionEnd = doc.content.size;
+  return sectionStart < sectionEnd ? { from: sectionStart, to: sectionEnd } : null;
+}
+
+/** Build decorations: toggle widget per heading + hiding class on collapsed content. */
+function computeDecorations(doc: Node, state: Pick<CollapsePluginState, "collapsed" | "headingKeys">): DecorationSet {
+  const decorations: Decoration[] = [];
+  const { collapsed, headingKeys } = state;
+
+  doc.forEach((node, offset) => {
+    if (node.type.name !== "heading") return;
+
+    const key = headingKeys.get(offset);
+    if (!key) return;
+    const isCollapsed = collapsed.has(key);
+    const level = node.attrs.level as number;
+
+    // Toggle arrow widget (inside heading, before text)
+    decorations.push(
+      Decoration.widget(
+        offset + 1,
+        () => {
+          const arrow = document.createElement("span");
+          arrow.className = `heading-collapse-toggle${isCollapsed ? " collapsed" : ""}`;
+          arrow.textContent = isCollapsed ? "▶" : "▼";
+          arrow.setAttribute("contenteditable", "false");
+          arrow.dataset.headingKey = key;
+          return arrow;
+        },
+        { side: -2 },
+      ),
+    );
+
+    // Indicator on collapsed heading itself
+    if (isCollapsed) {
+      decorations.push(
+        Decoration.node(offset, offset + node.nodeSize, {
+          class: "heading-collapsed-indicator",
+        }),
+      );
+
+      // Hide section content nodes
+      const range = getSectionRange(doc, offset, level);
+      if (range) {
+        doc.nodesBetween(range.from, range.to, (child, childPos) => {
+          if (childPos < range.from) return true; // skip doc node
+          decorations.push(
+            Decoration.node(childPos, childPos + child.nodeSize, {
+              class: "collapsed-content",
+            }),
+          );
+          return false;
+        });
+      }
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const HeadingCollapse = Extension.create({
+  name: "headingCollapse",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<CollapsePluginState>({
+        key: collapsePluginKey,
+        state: {
+          init(_, editorState: EditorState): CollapsePluginState {
+            const collapsed = new Set<string>();
+            const headingKeys = computeHeadingKeys(editorState.doc);
+            const decorations = computeDecorations(editorState.doc, { collapsed, headingKeys });
+            return { collapsed, headingKeys, decorations };
+          },
+          apply(tr: Transaction, value: CollapsePluginState): CollapsePluginState {
+            const meta = tr.getMeta(collapsePluginKey) as CollapseMeta | undefined;
+
+            if (meta?.type === "toggle") {
+              const next = new Set(value.collapsed);
+              if (next.has(meta.key)) next.delete(meta.key);
+              else next.add(meta.key);
+              const keys = tr.docChanged ? computeHeadingKeys(tr.doc) : value.headingKeys;
+              const decorations = computeDecorations(tr.doc, { collapsed: next, headingKeys: keys });
+              return { collapsed: next, headingKeys: keys, decorations };
+            }
+
+            if (meta?.type === "restore") {
+              const keys = computeHeadingKeys(tr.doc);
+              const collapsed = new Set(meta.keys);
+              const decorations = computeDecorations(tr.doc, { collapsed, headingKeys: keys });
+              return { collapsed, headingKeys: keys, decorations };
+            }
+
+            if (!tr.docChanged) return value;
+            const headingKeys = computeHeadingKeys(tr.doc);
+            const decorations = computeDecorations(tr.doc, { collapsed: value.collapsed, headingKeys });
+            return { collapsed: value.collapsed, headingKeys, decorations };
+          },
+        },
+        props: {
+          decorations(state: EditorState): DecorationSet {
+            return (collapsePluginKey.getState(state) as CollapsePluginState).decorations;
+          },
+          handleDOMEvents: {
+            click(view: EditorView, event: MouseEvent): boolean {
+              const target = event.target as HTMLElement;
+              if (!target.classList.contains("heading-collapse-toggle")) return false;
+              const key = target.dataset.headingKey;
+              if (!key) return false;
+              event.preventDefault();
+              event.stopPropagation();
+              const tr = view.state.tr.setMeta(collapsePluginKey, { type: "toggle", key });
+              view.dispatch(tr);
+              return true;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** Restore collapsed state from saved keys (e.g., vscode.getState). */
+export function setCollapsedHeadings(view: EditorView, keys: string[]): void {
+  const tr = view.state.tr.setMeta(collapsePluginKey, { type: "restore", keys });
+  view.dispatch(tr);
+}
+
+/** Get currently collapsed heading keys. */
+export function getCollapsedHeadings(state: EditorState): string[] {
+  const pluginState = collapsePluginKey.getState(state) as CollapsePluginState | undefined;
+  return pluginState ? [...pluginState.collapsed] : [];
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -45,6 +45,7 @@ import { AlertNode, ALERT_REGEX, ALERT_TYPES, getFirstText, stripAlertPrefix } f
 import { TableContextMenu } from "./table-context-menu";
 import { Blockquote } from "@tiptap/extension-blockquote";
 import { setupTocSidebar, updateTocFromEditor, setTocDepthFilter, getTocDepthFilter } from "./toc-sidebar";
+import { HeadingCollapse, collapsePluginKey, getCollapsedHeadings, setCollapsedHeadings } from "./heading-collapse-plugin";
 
 // Fix: @tiptap/markdown v3.19.0 drops `escape` tokens from marked parser,
 // causing escaped characters like \_ to be silently lost during roundtrip.
@@ -131,6 +132,7 @@ interface WebviewState {
   theme?: string;
   tocVisible?: boolean;
   tocDepthFilter?: number[];
+  collapsedHeadings?: string[];
 }
 
 declare function acquireVsCodeApi(): {
@@ -695,6 +697,7 @@ function initEditor(initialContent: string = ""): Editor | null {
     // Build conditional extensions
     const conditionalExtensions = [
       HeadingLevel,
+      HeadingCollapse,
       ...(highlightCurrentLine ? [LineHighlight] : []),
     ];
 
@@ -912,6 +915,12 @@ function initEditor(initialContent: string = ""): Editor | null {
       onTransaction: ({ editor: ed, transaction: tr }) => {
         updateToolbarActiveState(ed);
         updateTocFromEditor(ed, tr.docChanged);
+        // Persist collapsed heading state on toggle only
+        const collapseMeta = tr.getMeta(collapsePluginKey);
+        if (collapseMeta?.type === "toggle") {
+          const keys = getCollapsedHeadings(ed.state);
+          vscode.setState({ ...vscode.getState(), collapsedHeadings: keys });
+        }
       },
     });
 
@@ -1148,6 +1157,13 @@ window.addEventListener("message", async (event) => {
           if (editor) {
             // Transform table cells: convert text patterns (-, N., [x]) to proper list nodes
             transformTableCellsAfterParse(editor);
+            // Restore collapsed headings from saved state after first init
+            if (justInitialized) {
+              const saved = vscode.getState();
+              if (saved?.collapsedHeadings?.length) {
+                setCollapsedHeadings(editor.view, saved.collapsedHeadings);
+              }
+            }
             // Update TOC after content change (skip if just initialized — initTocSidebar already did it)
             if (!justInitialized) updateTocFromEditor(editor, true);
           }


### PR DESCRIPTION
## Summary
- Fixed `display: flex` leaking from task list items to all nested `<li>` descendants, causing paragraphs and code blocks inside nested lists to render **side-by-side** instead of vertically stacked
- Changed 5 CSS selectors from descendant (`ul[data-type="taskList"] li`) to direct child combinator (`ul[data-type="taskList"] > li`)
- Bump version to 2.3.1

## Test plan
- [ ] Open a markdown file with task list items containing nested bullet lists and code blocks
- [ ] Verify nested content renders vertically (not side-by-side)
- [ ] Verify task list checkboxes still display correctly with label + content layout
- [ ] Verify checked task items still show strikethrough text