### PR TITLE
v2.5.1: Fix font rendering legibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.5.1] - 2026-03-27
+
+### Fixed
+
+* **Font Rendering**: Removed `-webkit-font-smoothing: antialiased` — text now renders thicker and more legible using default subpixel antialiasing
+
 ## \[2.5.0] - 2026-03-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -818,7 +818,6 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .tiptap {
             padding: 32px 48px 40vh 48px;
             caret-color: var(--crepe-color-primary);
-            -webkit-font-smoothing: antialiased;
             font-optical-sizing: auto;
             transition: background-color 0.3s ease, color 0.3s ease;
           }


### PR DESCRIPTION
## Summary
- Removed `-webkit-font-smoothing: antialiased` — text renders thicker and more legible using default subpixel antialiasing
- Bump version to 2.5.1

## Test plan
- [ ] Open a markdown file in the editor
- [ ] Verify text appears thicker/more readable than before
- [ ] Check all themes (light + dark) render correctly