### PR TITLE
feat: add in-editor search and link navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.6.0] - 2026-03-27
+
+### Added
+
+* **Search (Cmd+F)**: Find text in editor with `Cmd+F`/`Ctrl+F` — highlights all matches, navigate with Enter/Shift+Enter, match counter, glassmorphic search bar with slide-down animation. Powered by `prosemirror-search`.
+* **Link Click Navigation**: `Ctrl+Click` (`Cmd+Click` on macOS) on links — anchor links (`#heading`) scroll to heading, relative file links open in VSCode, external URLs open in browser. Pointer cursor shown when modifier key held.
+
 ## \[2.5.1] - 2026-03-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ src/
     ├── table-markdown-serializer.ts # Custom GFM table serializer (multi-line cells)
     ├── table-cell-content-parser.ts # Post-parse transformer for table cell lists/breaks
     ├── table-context-menu.ts # Right-click context menu for table operations
+    ├── search-plugin.ts      # Cmd+F search via prosemirror-search (highlight, next/prev, match count)
     ├── toc-sidebar.ts        # Table of Contents sidebar (extract, tree, render, active tracking)
     └── themes/               # Theme CSS files (scoped by body class)
         ├── index.css              # Imports all theme CSS
@@ -108,7 +109,7 @@ Extension provides these settings via `tuiMarkdown.*` namespace:
 
 Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for markdown roundtrip.
 
-**Extensions:** StarterKit (includes Link with `autolink: true, linkOnPaste: true`), Image, Highlight, Table (resizable + custom `renderMarkdown` hook), CodeBlockLowlight (syntax highlighting via lowlight/highlight.js), TaskList + TaskItem, Placeholder, Markdown (GFM + configurable indentation), AlertNode (GitHub-style alerts), MermaidDiagram (SVG preview), TableContextMenu (right-click menu), CodeBlockEnhancement (language badge + copy button).
+**Extensions:** StarterKit (includes Link with `autolink: true, linkOnPaste: true`), Image, Highlight, Table (resizable + custom `renderMarkdown` hook), CodeBlockLowlight (syntax highlighting via lowlight/highlight.js), TaskList + TaskItem, Placeholder, Markdown (GFM + configurable indentation), AlertNode (GitHub-style alerts), MermaidDiagram (SVG preview), TableContextMenu (right-click menu), CodeBlockEnhancement (language badge + copy button), SearchPlugin (Cmd+F via prosemirror-search).
 
 **Markdown API:**
 
@@ -448,6 +449,48 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 * XSS safe: Uses `textContent` (not `innerHTML`) for heading text
 
 * `vscode.setState()` must use spread pattern: `{ ...getState(), key: value }` to preserve other state (theme, TOC)
+
+## Search (Cmd+F)
+
+**Plugin** (`src/webview/search-plugin.ts`):
+
+* Tiptap Extension wrapping `prosemirror-search` package
+* `search()` ProseMirror plugin provides decoration-based match highlighting
+* `SearchQuery({ search, caseSensitive })` configures the search
+* `setSearchState(tr, query)` sets query via transaction meta
+* `findNext(state, dispatch)` / `findPrev(state, dispatch)` — standard ProseMirror commands
+* `getMatchHighlights(state)` returns DecorationSet; `.find()` gives match count
+* `Mod-f` intercepted via `addKeyboardShortcuts()`, dispatches `CustomEvent("toggle-search-bar")`
+
+**Search Bar UI** (in `src/markdownEditorProvider.ts` HTML + CSS):
+
+* Positioned between `#toolbar` and `#metadata-panel` in DOM
+* Glassmorphic style matching toolbar (`backdrop-filter: blur(12px)`, CSS variables)
+* Slide-down animation: `max-height: 0` → `40px` with `0.15s ease-out` transition
+* `.hidden` class controls visibility (same pattern as TOC sidebar)
+* Input debounced at 150ms, "no-results" red border on 0 matches
+
+**Keyboard shortcuts**: `Mod-f` toggle, `Enter` next, `Shift+Enter` prev, `Escape` close
+
+**CSS classes**: `.ProseMirror-search-match` (all matches, `rgba(--accent-rgb, 0.2)`), `.ProseMirror-active-search-match` (active, `0.45`). Dark theme uses higher opacity (`0.25`/`0.5`).
+
+**Dependencies**: `prosemirror-search@^1.1.0`
+
+## Link Click Navigation
+
+**Behavior** (in `src/webview/main.ts` + `src/markdownEditorProvider.ts`):
+
+* **Ctrl+Click** (`Cmd+Click` on macOS) triggers link navigation; regular click places cursor normally
+
+* **Anchor links** (`#heading-slug`): `scrollToHeading()` traverses `doc.descendants()`, generates GitHub-style slug (lowercase, special chars removed, spaces→hyphens), scrolls matching heading into view via `scrollIntoView({ behavior: "smooth" })`
+
+* **Relative file links** (`./file.md`, `../docs/readme.md`): Webview sends `openLink` message → Extension resolves path against `document.uri.fsPath` → `vscode.workspace.openTextDocument()` + `showTextDocument()`
+
+* **External URLs** (`https://...`): Extension calls `vscode.env.openExternal()`
+
+* **Cursor style**: `body.ctrl-held` class toggled via keydown/keyup listeners; CSS shows pointer cursor + underline on `.tiptap a`
+
+**Message type**: `openLink` (webview → extension, payload: `{ href: string }`)
 
 ## Code Block Enhancement
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 - **Table Context Menu**: Right-click on table cells for select/add/delete row/column/table actions
 - **Cell Selection Highlight**: Drag-selecting across table cells shows visual highlight overlay
 - **Theme Selection**: 10 editor themes including Catppuccin palette (4 variants)
+- **Search (Cmd+F)**: Find text in editor with match highlighting, next/prev navigation, and match counter
+- **Link Navigation**: Ctrl/Cmd+Click to follow links — scroll to headings, open files, or launch URLs in browser
 - **View Source**: Toggle between WYSIWYG and source view (Ctrl/Cmd+Shift+M)
 - **Cursor Line Highlight**: Visual highlight of current block/paragraph
 - **Table of Contents**: Sidebar with click-to-scroll, active heading tracking, and collapse/expand

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "2.0.8",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "2.0.8",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^3.19.0",
@@ -23,7 +23,8 @@
         "@tiptap/starter-kit": "^3.19.0",
         "js-yaml": "^4.1.1",
         "lowlight": "^3.3.0",
-        "mermaid": "^11.12.2"
+        "mermaid": "^11.12.2",
+        "prosemirror-search": "^1.1.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -2412,6 +2413,17 @@
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-search/-/prosemirror-search-1.1.0.tgz",
+      "integrity": "sha512-hnGINlrRs+St6scaF4hoGiR8b7V0ffddzvO/zy+ON8RwvVinfLk4rVsuSztLNthgvfE2LAOU4blsPr7yoeoLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.33.6"
       }
     },
     "node_modules/prosemirror-state": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",
@@ -157,6 +157,7 @@
     "@tiptap/starter-kit": "^3.19.0",
     "js-yaml": "^4.1.1",
     "lowlight": "^3.3.0",
-    "mermaid": "^11.12.2"
+    "mermaid": "^11.12.2",
+    "prosemirror-search": "^1.1.0"
   }
 }

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -537,6 +537,30 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               });
             break;
           }
+          case "openLink": {
+            const linkHref = (msg as { href?: string }).href;
+            if (!linkHref) break;
+
+            if (/^https?:\/\//.test(linkHref)) {
+              // External URL → open in default browser
+              vscode.env.openExternal(vscode.Uri.parse(linkHref));
+            } else {
+              // Relative file path → resolve against document location
+              const docDir = path.dirname(document.uri.fsPath);
+              // Separate file path and anchor fragment
+              const hashIndex = linkHref.indexOf("#");
+              const filePart = hashIndex !== -1 ? linkHref.slice(0, hashIndex) : linkHref;
+              const targetPath = filePart
+                ? path.resolve(docDir, filePart)
+                : document.uri.fsPath;
+              const targetUri = vscode.Uri.file(targetPath);
+              vscode.workspace.openTextDocument(targetUri).then(
+                (doc) => vscode.window.showTextDocument(doc),
+                () => vscode.window.showWarningMessage(`Cannot open file: ${linkHref}`)
+              );
+            }
+            break;
+          }
           case "requestLinkEdit": {
             const linkMsg = msg as { editId?: string; currentUrl?: string };
             if (!linkMsg.editId) break;
@@ -1589,6 +1613,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             text-decoration: none;
             border-bottom: 1px solid transparent;
           }
+          /* Ctrl/Cmd held: pointer cursor + underline on links */
+          body.ctrl-held .tiptap a {
+            cursor: pointer;
+            text-decoration: underline;
+          }
           /* Placeholder styling */
           .tiptap p.is-editor-empty:first-child::before {
             content: attr(data-placeholder);
@@ -2011,17 +2040,126 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             .tiptap img { border: 1px solid var(--vscode-panel-border); }
           }
 
+          /* Search bar */
+          #search-bar {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 12px;
+            background: rgba(var(--toolbar-bg-rgb), 0.85);
+            border-bottom: 1px solid rgba(var(--border-rgb), 0.15);
+            max-height: 40px;
+            overflow: hidden;
+            transition: max-height 0.15s ease-out, padding 0.15s ease-out;
+          }
+          @supports (backdrop-filter: blur(12px)) {
+            #search-bar {
+              backdrop-filter: blur(12px);
+              -webkit-backdrop-filter: blur(12px);
+              background: rgba(var(--toolbar-bg-rgb), 0.7);
+            }
+          }
+          #search-bar.hidden {
+            max-height: 0;
+            padding-top: 0;
+            padding-bottom: 0;
+            border-bottom-color: transparent;
+          }
+          .search-icon {
+            width: 14px;
+            height: 14px;
+            fill: none;
+            stroke: var(--toolbar-fg);
+            stroke-width: 2;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+            opacity: 0.5;
+            flex-shrink: 0;
+          }
+          #search-input {
+            flex: 1;
+            max-width: 300px;
+            background: rgba(var(--border-rgb), 0.1);
+            border: 1px solid rgba(var(--border-rgb), 0.2);
+            border-radius: 4px;
+            padding: 3px 8px;
+            font-size: 13px;
+            font-family: inherit;
+            color: var(--toolbar-fg);
+            outline: none;
+            transition: border-color 0.15s ease;
+          }
+          #search-input:focus {
+            border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.5);
+          }
+          #search-input.no-results {
+            border-color: rgba(220, 38, 38, 0.6);
+          }
+          #search-count {
+            font-size: 12px;
+            color: var(--toolbar-fg);
+            opacity: 0.6;
+            min-width: 36px;
+            text-align: center;
+            white-space: nowrap;
+          }
+          .search-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 22px;
+            height: 22px;
+            border: none;
+            background: transparent;
+            border-radius: 4px;
+            cursor: pointer;
+            color: var(--toolbar-fg);
+            padding: 0;
+            transition: background-color 0.1s ease;
+          }
+          .search-btn:hover {
+            background: rgba(var(--border-rgb), 0.15);
+          }
+          .search-btn:active {
+            transform: scale(0.93);
+          }
+          .search-btn svg {
+            width: 14px;
+            height: 14px;
+            fill: none;
+            stroke: currentColor;
+            stroke-width: 2;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+          }
+
+          /* Search match highlights (prosemirror-search) */
+          .ProseMirror-search-match {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.2);
+            border-radius: 2px;
+          }
+          .ProseMirror-active-search-match {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.45);
+            border-radius: 2px;
+          }
+          body.dark-theme .ProseMirror-search-match {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.25);
+          }
+          body.dark-theme .ProseMirror-active-search-match {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.5);
+          }
+
           /* Reduced motion — respect OS accessibility setting */
           @media (prefers-reduced-motion: reduce) {
             .tiptap *, .tiptap *::before, .tiptap *::after,
             .toolbar-btn, .view-source-btn, #heading-select, #theme-select,
             .mermaid-code-block, .mermaid-preview, .image-edit-overlay,
-            .toc-entry, .code-copy-btn,
+            .toc-entry, .code-copy-btn, #search-bar, #search-input,
             html, body, #toolbar {
               transition-duration: 0.01ms !important;
               animation-duration: 0.01ms !important;
             }
-            .toolbar-btn:active { transform: none !important; }
+            .toolbar-btn:active, .search-btn:active { transform: none !important; }
           }
 
         </style>
@@ -2145,6 +2283,20 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             </select>
             <button id="btn-source" class="view-source-btn" aria-label="View source in text editor">Source</button>
           </div>
+        </div>
+        <div id="search-bar" class="hidden">
+          <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input id="search-input" type="text" placeholder="Search..." spellcheck="false" autocomplete="off" maxlength="500" />
+          <span id="search-count"></span>
+          <button id="search-prev" class="search-btn" title="Previous (Shift+Enter)" aria-label="Previous match">
+            <svg viewBox="0 0 24 24"><polyline points="18 15 12 9 6 15"/></svg>
+          </button>
+          <button id="search-next" class="search-btn" title="Next (Enter)" aria-label="Next match">
+            <svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg>
+          </button>
+          <button id="search-close" class="search-btn" title="Close (Escape)" aria-label="Close search">
+            <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
         <div id="metadata-panel">
           <details id="metadata-details" class="hidden">

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -47,6 +47,7 @@ import { Blockquote } from "@tiptap/extension-blockquote";
 import { setupTocSidebar, updateTocFromEditor } from "./toc-sidebar";
 import { HeadingCollapse, collapsePluginKey, getCollapsedHeadings, setCollapsedHeadings } from "./heading-collapse-plugin";
 import { CodeBlockEnhancement } from "./code-block-plugin";
+import { SearchPlugin, performSearch, clearSearch, searchNext, searchPrev, getMatchInfo } from "./search-plugin";
 
 // Fix: @tiptap/markdown v3.19.0 drops `escape` tokens from marked parser,
 // causing escaped characters like \_ to be silently lost during roundtrip.
@@ -802,6 +803,7 @@ function initEditor(initialContent: string = ""): Editor | null {
         CodeExitHandler,
         MermaidDiagram,
         TableContextMenu,
+        SearchPlugin,
         ...conditionalExtensions,
       ],
       content: initialContent,
@@ -1071,6 +1073,99 @@ function updateToolbarActiveState(ed: Editor): void {
   }
 }
 
+// Search bar handlers
+function setupSearchBar(): void {
+  const searchBar = document.getElementById("search-bar");
+  const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
+  const searchCount = document.getElementById("search-count");
+  const searchPrevBtn = document.getElementById("search-prev");
+  const searchNextBtn = document.getElementById("search-next");
+  const searchCloseBtn = document.getElementById("search-close");
+  if (!searchBar || !searchInput) return;
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function updateCount(): void {
+    if (!searchCount || !editor) return;
+    const info = getMatchInfo(editor);
+    if (info.count > 0) {
+      searchCount.textContent = `${info.activeIndex}/${info.count}`;
+      searchInput?.classList.remove("no-results");
+    } else if (searchInput && searchInput.value.length > 0) {
+      searchCount.textContent = "0";
+      searchInput.classList.add("no-results");
+    } else {
+      searchCount.textContent = "";
+      searchInput?.classList.remove("no-results");
+    }
+  }
+
+  function openSearchBar(): void {
+    searchBar!.classList.remove("hidden");
+    searchInput!.focus();
+    searchInput!.select();
+  }
+
+  function closeSearchBar(): void {
+    if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+    searchBar!.classList.add("hidden");
+    searchInput!.value = "";
+    searchCount!.textContent = "";
+    searchInput!.classList.remove("no-results");
+    if (editor) {
+      clearSearch(editor);
+      editor.commands.focus();
+    }
+  }
+
+  function toggleSearchBar(): void {
+    if (searchBar!.classList.contains("hidden")) {
+      openSearchBar();
+    } else {
+      closeSearchBar();
+    }
+  }
+
+  // Listen for Mod-f from search-plugin.ts
+  document.addEventListener("toggle-search-bar", toggleSearchBar);
+
+  // Input → debounced search
+  searchInput.addEventListener("input", () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if (!editor) return;
+      performSearch(editor, searchInput.value);
+      // After setting query, navigate to first match
+      if (searchInput.value.length > 0) {
+        searchNext(editor);
+      }
+      updateCount();
+    }, 150);
+  });
+
+  // Keyboard shortcuts in search input
+  searchInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (editor) { searchNext(editor); updateCount(); }
+    } else if (e.key === "Enter" && e.shiftKey) {
+      e.preventDefault();
+      if (editor) { searchPrev(editor); updateCount(); }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      closeSearchBar();
+    }
+  });
+
+  searchNextBtn?.addEventListener("click", () => {
+    if (editor) { searchNext(editor); updateCount(); }
+  });
+  searchPrevBtn?.addEventListener("click", () => {
+    if (editor) { searchPrev(editor); updateCount(); }
+  });
+  searchCloseBtn?.addEventListener("click", closeSearchBar);
+}
+
 // Toolbar event handlers
 function setupToolbarHandlers(): void {
   const themeSelect = getThemeSelect();
@@ -1110,6 +1205,63 @@ function setupToolbarHandlers(): void {
     if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "m") {
       e.preventDefault();
       viewSource();
+    }
+  });
+
+  // Link click navigation: Ctrl/Cmd+Click opens links
+  document.addEventListener("click", (e) => {
+    if (!e.ctrlKey && !e.metaKey) return;
+    const anchor = (e.target as HTMLElement).closest<HTMLAnchorElement>("a[href]");
+    if (!anchor || !editor) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const href = anchor.getAttribute("href") || "";
+    if (href.startsWith("#")) {
+      scrollToHeading(href.slice(1));
+    } else {
+      vscode.postMessage({ type: "openLink", href });
+    }
+  });
+
+  // Ctrl/Cmd held → pointer cursor on links
+  document.addEventListener("keydown", (e) => {
+    if (e.ctrlKey || e.metaKey) document.body.classList.add("ctrl-held");
+  });
+  document.addEventListener("keyup", (e) => {
+    if (!e.ctrlKey && !e.metaKey) document.body.classList.remove("ctrl-held");
+  });
+  window.addEventListener("blur", () => document.body.classList.remove("ctrl-held"));
+}
+
+/** Scroll editor to heading matching GitHub-style slug */
+function scrollToHeading(slug: string): void {
+  if (!editor) return;
+  const { doc } = editor.state;
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "heading") return;
+    const text = node.textContent;
+    // GitHub-style slug: lowercase, keep Unicode letters/digits, each space→one hyphen (no collapse)
+    const nodeSlug = text
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s-]/gu, "")
+      .replace(/\s/g, "-");
+    if (nodeSlug === slug) {
+      editor!.commands.setTextSelection(pos + 1);
+      const dom = editor!.view.nodeDOM(pos);
+      if (dom instanceof HTMLElement) {
+        const scroller = document.getElementById("editor-container");
+        if (scroller) {
+          const elRect = dom.getBoundingClientRect();
+          const scrollerRect = scroller.getBoundingClientRect();
+          const targetTop = elRect.top - scrollerRect.top + scroller.scrollTop - 60;
+          scroller.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
+        } else {
+          dom.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      }
+      return false;
     }
   });
 }
@@ -1285,6 +1437,7 @@ function init() {
   });
 
   setupToolbarHandlers();
+  setupSearchBar();
   setupMetadataHandlers();
   setupTocHandlers();
 

--- a/src/webview/search-plugin.ts
+++ b/src/webview/search-plugin.ts
@@ -1,0 +1,86 @@
+import { Editor, Extension } from "@tiptap/core";
+import { search, SearchQuery, findNext, findPrev, setSearchState, getMatchHighlights, getSearchState } from "prosemirror-search";
+
+export interface SearchMatchInfo {
+  count: number;
+  activeIndex: number;
+}
+
+/**
+ * Tiptap Extension wrapping prosemirror-search.
+ * Provides search decorations and Mod-f intercept.
+ */
+export const SearchPlugin = Extension.create({
+  name: "searchPlugin",
+
+  addProseMirrorPlugins() {
+    return [search()];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-f": () => {
+        document.dispatchEvent(new CustomEvent("toggle-search-bar"));
+        return true;
+      },
+    };
+  },
+});
+
+/** Set or update the search query, highlighting all matches */
+export function performSearch(editor: Editor, queryText: string): void {
+  const query = new SearchQuery({
+    search: queryText,
+    caseSensitive: false,
+  });
+  const { dispatch, state } = editor.view;
+  dispatch(setSearchState(state.tr, query));
+}
+
+/** Clear all search highlights */
+export function clearSearch(editor: Editor): void {
+  const query = new SearchQuery({ search: "" });
+  const { dispatch, state } = editor.view;
+  dispatch(setSearchState(state.tr, query));
+}
+
+/** Navigate to the next match (ProseMirror command) */
+export function searchNext(editor: Editor): void {
+  const { state, dispatch } = editor.view;
+  findNext(state, dispatch);
+}
+
+/** Navigate to the previous match (ProseMirror command) */
+export function searchPrev(editor: Editor): void {
+  const { state, dispatch } = editor.view;
+  findPrev(state, dispatch);
+}
+
+/** Get current match count and active match index */
+export function getMatchInfo(editor: Editor): SearchMatchInfo {
+  const state = editor.view.state;
+  const searchState = getSearchState(state);
+  if (!searchState || !searchState.query.valid) {
+    return { count: 0, activeIndex: 0 };
+  }
+  const decos = getMatchHighlights(state);
+  const allMatches = decos.find();
+  const count = allMatches.length;
+  if (count === 0) return { count: 0, activeIndex: 0 };
+
+  // Find active match by checking which decoration overlaps the current selection
+  const { from } = state.selection;
+  let activeIndex = 0;
+  for (let i = 0; i < allMatches.length; i++) {
+    if (allMatches[i].from <= from && allMatches[i].to >= from) {
+      activeIndex = i + 1;
+      break;
+    }
+    if (allMatches[i].from > from) {
+      activeIndex = i + 1;
+      break;
+    }
+  }
+  if (activeIndex === 0) activeIndex = count;
+  return { count, activeIndex };
+}


### PR DESCRIPTION
## Summary
- Implement Cmd+F search via `prosemirror-search` with highlight, next/prev navigation, and match count
- Add Ctrl+Click link navigation: anchor links scroll to heading, relative file links open in VS Code, external URLs open in browser
- New glassmorphic search bar UI with slide-down animation, keyboard shortcuts (Enter/Shift+Enter/Escape)

## Test plan
- [ ] Open a markdown file, press Cmd+F — search bar appears
- [ ] Type a search term — matches highlight, count displays
- [ ] Enter/Shift+Enter navigate between matches
- [ ] Escape closes search bar
- [ ] Ctrl+Click on anchor link scrolls to heading
- [ ] Ctrl+Click on relative file link opens the file
- [ ] Ctrl+Click on external URL opens in browser