### PR TITLE
fix: edge case hardening v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.6.2] - 2026-03-28
+
+### Fixed
+
+* **Image Path Regex**: Support nested parentheses in image paths (e.g., `path(1).png`) and angle-bracket syntax (`<path>`) in `extractImagePaths()`
+* **Code Block Protection**: Skip fenced code blocks when updating image references across workspace — prevents accidental code modification
+* **Path Traversal Hardening**: Decode URL-encoded characters (`%2e%2e`) before path traversal check in `hasPathTraversal()`
+* **Case-Sensitive Image Delete**: Remove `toLowerCase()` from filename comparison in `detectImageDeletes()` — fixes false positives on case-sensitive file systems (Linux)
+* **Search Count Stale**: Update search match count when content changes externally (e.g., another editor modifies the file)
+* **Heading Collapse Persistence**: Migrate collapsed heading state when heading text is edited — headings no longer unexpectedly uncollapse on text changes
+
 ## \[2.6.1] - 2026-03-28
 
 ### Improved

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -27,10 +27,12 @@ function extractImagePaths(content: string): string[] {
   const paths: string[] = [];
 
   // Markdown: ![alt](path) or ![alt](path "title") or ![alt](<path> "title")
-  const mdRegex = /!\[[^\]]*\]\(([^)]+)\)/g;
+  // Supports angle-bracket paths and paths with parentheses like path(1).png
+  const mdRegex = /!\[[^\]]*\]\((?:<([^>]+)>|([^)\s]+(?:\([^)]*\)[^)\s]*)*))\s*(?:["'][^"']*["'])?\)/g;
   let match;
   while ((match = mdRegex.exec(content)) !== null) {
-    const cleanPath = cleanImagePath(match[1]);
+    const rawPath = match[1] ?? match[2]; // match[1] = angle-bracket path, match[2] = normal path
+    const cleanPath = cleanImagePath(rawPath);
     if (cleanPath) {
       paths.push(cleanPath);
     }

--- a/src/utils/image-rename-handler.ts
+++ b/src/utils/image-rename-handler.ts
@@ -40,10 +40,17 @@ function isPathWithinDir(resolvedPath: string, allowedDir: string): boolean {
  * Note: Uses segment-aware ".." check to avoid false positives like "image..png"
  */
 export function hasPathTraversal(p: string): boolean {
+  // Decode URL-encoded characters before checking (prevents %2e%2e bypass)
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(p);
+  } catch {
+    return true; // Malformed encoding = suspicious
+  }
   // Block absolute paths (Unix and Windows)
-  if (p.startsWith("/") || /^[a-zA-Z]:/.test(p)) return true;
+  if (decoded.startsWith("/") || /^[a-zA-Z]:/.test(decoded)) return true;
   // Block ".." only as standalone path segment (not in filenames like "image..png")
-  const segments = p.split(/[\\/]/);
+  const segments = decoded.split(/[\\/]/);
   return segments.some(seg => seg === "..");
 }
 
@@ -227,13 +234,34 @@ export async function updateWorkspaceReferences(
         const newRef = rename.newRelative;
 
         if (text.includes(oldRef)) {
-          // Context-aware replacement: only in image/link references
+          // Context-aware replacement: only in image/link references, skip fenced code blocks
           const escapedOld = oldRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
           const contextRegex = new RegExp(
             `(\\]\\(|src=["'])${escapedOld}([)"'])`,
             "g"
           );
-          const newText = text.replace(contextRegex, `$1${newRef}$2`);
+
+          // Split text by fenced code blocks, only replace in non-code sections
+          const fenceRegex = /^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1/gm;
+          const parts: Array<{ text: string; isCode: boolean }> = [];
+          let lastIndex = 0;
+          let fenceMatch: RegExpExecArray | null;
+          fenceRegex.lastIndex = 0;
+          while ((fenceMatch = fenceRegex.exec(text)) !== null) {
+            if (fenceMatch.index > lastIndex) {
+              parts.push({ text: text.slice(lastIndex, fenceMatch.index), isCode: false });
+            }
+            parts.push({ text: fenceMatch[0], isCode: true });
+            lastIndex = fenceMatch.index + fenceMatch[0].length;
+          }
+          if (lastIndex < text.length) {
+            parts.push({ text: text.slice(lastIndex), isCode: false });
+          }
+
+          const newText = parts
+            .map(part => part.isCode ? part.text : part.text.replace(contextRegex, `$1${newRef}$2`))
+            .join("");
+
           if (newText !== text) {
             text = newText;
             modified = true;
@@ -283,9 +311,9 @@ export function detectImageDeletes(
     const normalizedCurrentPaths = new Set(
       currentPaths.map((p) => normalizePath(p)),
     );
-    // Build set of current filenames for "move" detection
+    // Build set of current filenames for "move" detection (case-sensitive for Linux FS correctness)
     const currentFilenames = new Set(
-      currentPaths.map((p) => path.basename(p).toLowerCase()),
+      currentPaths.map((p) => path.basename(p)),
     );
 
     for (const [origRelative, origAbsolute] of originalPaths) {
@@ -293,7 +321,7 @@ export function detectImageDeletes(
 
       // If original path not in current paths → potentially deleted
       if (!normalizedCurrentPaths.has(normalizedOrig)) {
-        const origFilename = path.basename(origRelative).toLowerCase();
+        const origFilename = path.basename(origRelative);
 
         // Check if same filename exists in different folder (move operation)
         if (currentFilenames.has(origFilename)) {

--- a/src/webview/heading-collapse-plugin.ts
+++ b/src/webview/heading-collapse-plugin.ts
@@ -141,8 +141,51 @@ export const HeadingCollapse = Extension.create({
             }
 
             if (!tr.docChanged) return value;
-            const { headingKeys, decorations } = computeKeysAndDecorations(tr.doc, value.collapsed);
-            return { collapsed: value.collapsed, headingKeys, decorations };
+
+            // Compute new keys from updated doc
+            const { headingKeys: newKeys, decorations } = computeKeysAndDecorations(tr.doc, value.collapsed);
+
+            // Migrate collapsed keys that changed due to heading text edits
+            // Key format: "H{level}:{text}:{idx}" — idx is after the last colon
+            const newKeySet = new Set(newKeys.values());
+            const migratedCollapsed = new Set<string>();
+            let needsMigration = false;
+
+            for (const oldKey of value.collapsed) {
+              if (newKeySet.has(oldKey)) {
+                migratedCollapsed.add(oldKey);
+              } else {
+                // Key disappeared — find replacement by same level + same occurrence index
+                // Use first colon for level prefix (handles text with colons like "Chapter 1: Details")
+                const lastColon = oldKey.lastIndexOf(":");
+                const firstColon = oldKey.indexOf(":");
+                if (lastColon > firstColon && firstColon !== -1) {
+                  const levelPrefix = oldKey.slice(0, firstColon + 1); // "H{level}:"
+                  const idx = oldKey.slice(lastColon); // ":{idx}"
+                  for (const nk of newKeySet) {
+                    const nkLastColon = nk.lastIndexOf(":");
+                    const nkFirstColon = nk.indexOf(":");
+                    if (
+                      nkLastColon > nkFirstColon &&
+                      nk.slice(0, nkFirstColon + 1) === levelPrefix &&
+                      nk.slice(nkLastColon) === idx &&
+                      !migratedCollapsed.has(nk)
+                    ) {
+                      migratedCollapsed.add(nk);
+                      needsMigration = true;
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+
+            if (needsMigration) {
+              const recomputed = computeKeysAndDecorations(tr.doc, migratedCollapsed);
+              return { collapsed: migratedCollapsed, headingKeys: recomputed.headingKeys, decorations: recomputed.decorations };
+            }
+
+            return { collapsed: value.collapsed, headingKeys: newKeys, decorations };
           },
         },
         props: {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1344,6 +1344,25 @@ window.addEventListener("message", async (event) => {
             }
             // Update TOC after content change (skip if just initialized — initTocSidebar already did it)
             if (!justInitialized) updateTocFromEditor(editor, true);
+            // Cập nhật số lượng kết quả tìm kiếm nếu search bar đang hiển thị
+            const searchBar = document.getElementById("search-bar");
+            if (searchBar && !searchBar.classList.contains("hidden")) {
+              const searchCount = document.getElementById("search-count");
+              const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
+              if (searchCount) {
+                const info = getMatchInfo(editor);
+                if (info.count > 0) {
+                  searchCount.textContent = `${info.activeIndex}/${info.count}`;
+                  searchInput?.classList.remove("no-results");
+                } else if (searchInput && searchInput.value.length > 0) {
+                  searchCount.textContent = "0";
+                  searchInput.classList.add("no-results");
+                } else {
+                  searchCount.textContent = "";
+                  searchInput?.classList.remove("no-results");
+                }
+              }
+            }
           }
         } catch (err) {
           console.error("[Tiptap] Update failed:", err);


### PR DESCRIPTION
## Summary
- **Image path regex**: Support nested parentheses (`path(1).png`) and angle-bracket syntax in `extractImagePaths()`
- **Code block protection**: Skip fenced code blocks when updating workspace image references
- **Path traversal hardening**: Decode URL-encoded characters (`%2e%2e`) before security check
- **Case-sensitive delete detection**: Fix false positives on Linux (case-sensitive FS)
- **Search count**: Update match count when content changes externally
- **Heading collapse**: Migrate collapsed state when heading text is edited

## Context
Parallel edge case review identified 35 potential issues across the codebase. 7 medium/low severity issues were fixed. Full report: `plans/reports/codebase-review-260328-0801-parallel-edge-case-verification.md`

## Files Changed
- `src/markdownEditorProvider.ts` — image path regex improvement
- `src/utils/image-rename-handler.ts` — URL decode, code block skip, case-sensitive fix
- `src/webview/main.ts` — search count update on external changes
- `src/webview/heading-collapse-plugin.ts` — key migration for collapse state

## Test plan
- [ ] Verify image with parentheses in filename displays correctly: `![alt](images/photo(1).png)`
- [ ] Verify image rename doesn't modify paths inside fenced code blocks
- [ ] Verify search match count updates when file is edited externally
- [ ] Verify heading collapse state persists after editing heading text
- [ ] Verify `npm run lint` and `npm run build` pass