### PR TITLE
feat: searchable font selector on toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.7.0] - 2026-04-01
+
+### Added
+
+* **Font Selector**: Searchable font picker on toolbar — browse and search all system fonts with live preview, persisted across sessions (does not affect code font)
+
 ## \[2.6.3] - 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ src/
     ├── table-cell-content-parser.ts # Post-parse transformer for table cell lists/breaks
     ├── table-context-menu.ts # Right-click context menu for table operations
     ├── search-plugin.ts      # Cmd+F search via prosemirror-search (highlight, next/prev, match count)
+    ├── font-selector.ts      # Searchable font combobox (system font enumeration, live preview, CSS sanitization)
     ├── toc-sidebar.ts        # Table of Contents sidebar (extract, tree, render, active tracking)
     └── themes/               # Theme CSS files (scoped by body class)
         ├── index.css              # Imports all theme CSS
@@ -495,6 +496,38 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 **CSS classes**: `.ProseMirror-search-match` (all matches, `rgba(--accent-rgb, 0.2)`), `.ProseMirror-active-search-match` (active, `0.45`). Dark theme uses higher opacity (`0.25`/`0.5`).
 
 **Dependencies**: `prosemirror-search@^1.1.0`
+
+## Font Selector
+
+**Module** (`src/webview/font-selector.ts`):
+
+* Searchable combobox component: text input + dropdown with all system fonts
+* `sanitizeFontName()`: Strips `";\{}` characters to prevent CSS injection
+* Search ranking: prefix matches first, then contains matches, max 80 displayed
+* Each dropdown item previewed in its own font face
+* Keyboard: Arrow keys navigate, Enter selects, Escape closes
+* API: `setFonts()`, `setSelected()`, `getSelected()`, `destroy()`
+
+**System Font Enumeration** (`src/markdownEditorProvider.ts`):
+
+* macOS: `NSFontManager` via JXA (`osascript -l JavaScript`)
+* Windows: PowerShell `InstalledFontCollection` with UTF-8 encoding
+* Linux: `fc-list : family`
+* Cached as `static cachedFonts` — enumerated once per VSCode session
+
+**Data Flow**:
+
+1. Webview `ready` → Extension sends `savedFont` (from `globalState`) + async `systemFonts`
+2. User selects font → Webview overrides `--crepe-font-default` CSS var on `.tiptap` element
+3. Webview persists via `vscode.setState({ fontFamily })` + sends `fontChange` message
+4. Extension saves to `context.globalState` key `"markdownEditorFont"`
+5. "Default" option removes CSS override, restoring theme's built-in font
+
+**Key details**:
+
+* Only overrides `--crepe-font-default` — never touches `--crepe-font-code`
+* Font override survives theme changes (inline style > CSS class)
+* `try/catch` around async `postMessage` to handle webview disposed during font enum
 
 ## Link Click Navigation
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 - **Local Image Display**: Renders local images from document folder and workspace
 - **Tab Indentation**: Tab key inserts 2-space indentation inside code blocks
 - **Large File Warning**: Protection for files >500KB
+- **Font Selector**: Searchable font picker on toolbar — browse all system fonts with live preview
 - **Configurable Font Size**: Adjust editor font size (8-32px)
 - **Configurable Heading Sizes**: Customize font sizes for H1-H6 headings (12-72px)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { exec } from "child_process";
 import * as vscode from "vscode";
 import { MAX_FILE_SIZE } from "./constants";
 import { getNonce } from "./utils/getNonce";
@@ -138,7 +139,58 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
    */
   private originalImagePaths: Map<string, Map<string, string>> = new Map();
 
+  /** Cached system font list — enumerated once, shared across all editors */
+  private static cachedFonts: string[] | null = null;
+
   constructor(private readonly context: vscode.ExtensionContext) { }
+
+  /** Enumerate system font families (cached after first call) */
+  private async getSystemFonts(): Promise<string[]> {
+    if (MarkdownEditorProvider.cachedFonts) {
+      return MarkdownEditorProvider.cachedFonts;
+    }
+
+    const fonts = await new Promise<string[]>((resolve) => {
+      const platform = process.platform;
+      let cmd: string;
+
+      if (platform === "darwin") {
+        // macOS: use NSFontManager via JXA (fast, reliable, no dependencies)
+        cmd = `osascript -l JavaScript -e 'ObjC.import("AppKit"); var fm = $.NSFontManager.sharedFontManager; var f = fm.availableFontFamilies; var r = []; for (var i = 0; i < f.count; i++) r.push(f.objectAtIndex(i).js); JSON.stringify(r);'`;
+      } else if (platform === "win32") {
+        cmd = `powershell -NoProfile -Command "[Console]::OutputEncoding = [Text.Encoding]::UTF8; [System.Reflection.Assembly]::LoadWithPartialName('System.Drawing') | Out-Null; (New-Object System.Drawing.Text.InstalledFontCollection).Families | ForEach-Object { $_.Name }"`;
+      } else {
+        cmd = `fc-list : family`;
+      }
+
+      exec(cmd, { timeout: 15000 }, (err, stdout) => {
+        if (err) {
+          resolve([]);
+          return;
+        }
+
+        let result: string[];
+        if (platform === "darwin") {
+          try {
+            result = JSON.parse(stdout.trim());
+          } catch {
+            result = [];
+          }
+        } else {
+          // fc-list may return comma-separated families per line
+          result = stdout
+            .split(/[\n,]/)
+            .map((f) => f.trim())
+            .filter((f) => f.length > 0);
+        }
+
+        resolve([...new Set(result)].sort((a, b) => a.localeCompare(b)));
+      });
+    });
+
+    MarkdownEditorProvider.cachedFonts = fonts;
+    return fonts;
+  }
 
   async resolveCustomTextEditor(
     document: vscode.TextDocument,
@@ -373,9 +425,28 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 theme: savedTheme,
               });
             }
+            // Send saved font
+            const savedFont = this.context.globalState.get<string>(
+              "markdownEditorFont",
+            );
+            if (savedFont) {
+              webviewPanel.webview.postMessage({
+                type: "savedFont",
+                font: savedFont,
+              });
+            }
             sendTheme();
             sendConfig();
             updateWebview();
+            // Send system fonts asynchronously (non-blocking)
+            this.getSystemFonts().then((fonts) => {
+              try {
+                webviewPanel.webview.postMessage({
+                  type: "systemFonts",
+                  fonts,
+                });
+              } catch { /* webview disposed */ }
+            });
             break;
           }
           case "edit":
@@ -399,6 +470,16 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               await this.context.globalState.update(
                 "markdownEditorTheme",
                 theme,
+              );
+            }
+            break;
+          }
+          case "fontChange": {
+            const font = (msg as { font?: string }).font;
+            if (typeof font === "string") {
+              await this.context.globalState.update(
+                "markdownEditorFont",
+                font || undefined, // Remove key when "Default"
               );
             }
             break;
@@ -1077,6 +1158,85 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           #theme-select:hover {
             background-color: rgba(var(--border-rgb, 0, 0, 0), 0.1);
             border-color: rgba(var(--border-rgb, 0, 0, 0), 0.15);
+          }
+          /* Font selector combobox */
+          .font-selector {
+            position: relative;
+          }
+          .font-selector-input {
+            -webkit-appearance: none;
+            appearance: none;
+            background-color: rgba(var(--border-rgb, 0, 0, 0), 0.05);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 6px center;
+            padding: 4px 24px 4px 8px;
+            border: 1px solid rgba(var(--border-rgb, 0, 0, 0), 0.08);
+            border-radius: 6px;
+            height: 30px;
+            width: 120px;
+            color: inherit;
+            cursor: pointer;
+            font-size: 11px;
+            transition: background-color 0.15s ease-out, border-color 0.15s ease-out;
+            box-sizing: border-box;
+          }
+          .font-selector-input::placeholder {
+            color: var(--toolbar-fg, inherit);
+            opacity: 0.7;
+          }
+          .font-selector-input:hover {
+            background-color: rgba(var(--border-rgb, 0, 0, 0), 0.1);
+            border-color: rgba(var(--border-rgb, 0, 0, 0), 0.15);
+          }
+          .font-selector-input:focus {
+            outline: none;
+            border-color: rgba(var(--accent-rgb, 100, 100, 255), 0.5);
+            background-image: none;
+            cursor: text;
+            width: 160px;
+          }
+          .font-selector-dropdown {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            margin-top: 4px;
+            width: 220px;
+            max-height: 256px;
+            overflow-y: auto;
+            background: var(--vscode-editor-background, #fff);
+            color: var(--vscode-editor-foreground, #333);
+            border: 1px solid rgba(var(--border-rgb, 0, 0, 0), 0.15);
+            border-radius: 8px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+            z-index: 1000;
+            overscroll-behavior: contain;
+          }
+          .font-selector-item {
+            padding: 6px 12px;
+            cursor: pointer;
+            font-size: 13px;
+            line-height: 20px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            color: var(--vscode-editor-foreground, #333);
+            transition: background-color 0.1s ease;
+          }
+          .font-selector-item:hover,
+          .font-selector-item.highlighted {
+            background-color: rgba(var(--accent-rgb, 100, 100, 255), 0.15);
+          }
+          .font-selector-item.selected {
+            color: rgba(var(--accent-rgb, 100, 100, 255), 1);
+            font-weight: 600;
+          }
+          .font-selector-empty {
+            padding: 8px 12px;
+            font-size: 12px;
+            color: var(--vscode-editor-foreground, #333);
+            opacity: 0.5;
+            font-style: italic;
           }
           .toolbar-spacer { flex: 1; }
           .view-source-btn {
@@ -2335,8 +2495,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
           <div class="toolbar-spacer"></div>
 
-          <!-- Theme & View Source (right side) -->
+          <!-- Font, Theme & View Source (right side) -->
           <div class="toolbar-group" style="gap: 6px;">
+            <div id="font-selector-container"></div>
             <select id="theme-select" aria-label="Editor theme">
               <option value="frame">Frame</option>
               <option value="frame-dark">Frame Dark</option>

--- a/src/webview/font-selector.ts
+++ b/src/webview/font-selector.ts
@@ -1,0 +1,298 @@
+/**
+ * Searchable font selector combobox for the toolbar.
+ * Renders a text input with dropdown list of system fonts,
+ * each previewed in its own font face.
+ */
+
+const DEFAULT_FONT_VALUE = "";
+const DEFAULT_FONT_LABEL = "Default";
+const MAX_FILTERED_DISPLAY = 80;
+
+/** Strip characters that break CSS string context */
+export function sanitizeFontName(name: string): string {
+  return name.replace(/[\\";{}]/g, "");
+}
+
+interface FontSelectorState {
+  fonts: string[];
+  selected: string;
+  filtered: string[];
+  highlightIndex: number;
+  isOpen: boolean;
+}
+
+type FontChangeCallback = (fontFamily: string) => void;
+
+export interface FontSelectorAPI {
+  setFonts: (fonts: string[]) => void;
+  setSelected: (fontFamily: string) => void;
+  getSelected: () => string;
+  destroy: () => void;
+}
+
+/**
+ * Initialize a searchable font selector inside the given container element.
+ * Returns an API object to control the selector programmatically.
+ */
+export function initFontSelector(
+  container: HTMLElement,
+  onFontChange: FontChangeCallback,
+): FontSelectorAPI {
+  const state: FontSelectorState = {
+    fonts: [],
+    selected: DEFAULT_FONT_VALUE,
+    filtered: [],
+    highlightIndex: -1,
+    isOpen: false,
+  };
+
+  // Build DOM structure
+  const wrapper = document.createElement("div");
+  wrapper.className = "font-selector";
+
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "font-selector-input";
+  input.placeholder = DEFAULT_FONT_LABEL;
+  input.setAttribute("aria-label", "Font family");
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("role", "combobox");
+  input.setAttribute("aria-expanded", "false");
+  input.spellcheck = false;
+  input.autocomplete = "off";
+
+  const dropdown = document.createElement("div");
+  dropdown.className = "font-selector-dropdown";
+  dropdown.setAttribute("role", "listbox");
+  dropdown.style.display = "none";
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(dropdown);
+  container.appendChild(wrapper);
+
+  // --- Helpers ---
+
+  function getDisplayName(fontFamily: string): string {
+    return fontFamily || DEFAULT_FONT_LABEL;
+  }
+
+  function updateFiltered(query: string): void {
+    const q = query.toLowerCase().trim();
+    if (!q) {
+      state.filtered = [DEFAULT_FONT_VALUE, ...state.fonts];
+    } else {
+      // Prefix matches first, then contains matches
+      const prefix: string[] = [];
+      const contains: string[] = [];
+      for (const f of state.fonts) {
+        const lower = f.toLowerCase();
+        if (lower.startsWith(q)) prefix.push(f);
+        else if (lower.includes(q)) contains.push(f);
+      }
+      state.filtered = [...prefix, ...contains].slice(0, MAX_FILTERED_DISPLAY);
+      // Include "Default" option if it matches
+      if (DEFAULT_FONT_LABEL.toLowerCase().includes(q)) {
+        state.filtered.unshift(DEFAULT_FONT_VALUE);
+      }
+    }
+    state.highlightIndex = -1;
+  }
+
+  function renderDropdown(): void {
+    dropdown.innerHTML = "";
+
+    if (state.filtered.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "font-selector-empty";
+      empty.textContent = "No fonts found";
+      dropdown.appendChild(empty);
+      return;
+    }
+
+    for (let i = 0; i < state.filtered.length; i++) {
+      const fontValue = state.filtered[i];
+      const item = document.createElement("div");
+      item.className = "font-selector-item";
+      item.setAttribute("role", "option");
+      item.textContent = getDisplayName(fontValue);
+
+      // Preview font in its own typeface (skip for Default)
+      if (fontValue) {
+        item.style.fontFamily = `"${sanitizeFontName(fontValue)}", sans-serif`;
+      }
+
+      if (fontValue === state.selected) {
+        item.classList.add("selected");
+      }
+      if (i === state.highlightIndex) {
+        item.classList.add("highlighted");
+      }
+
+      item.addEventListener("mousedown", (e) => {
+        e.preventDefault(); // Prevent input blur
+        selectFont(fontValue);
+      });
+
+      dropdown.appendChild(item);
+    }
+  }
+
+  function openDropdown(): void {
+    if (state.isOpen) return;
+    state.isOpen = true;
+    dropdown.style.display = "block";
+    input.setAttribute("aria-expanded", "true");
+    updateFiltered(input.value);
+    renderDropdown();
+    scrollToSelected();
+  }
+
+  function closeDropdown(): void {
+    if (!state.isOpen) return;
+    state.isOpen = false;
+    dropdown.style.display = "none";
+    input.setAttribute("aria-expanded", "false");
+    state.highlightIndex = -1;
+  }
+
+  function selectFont(fontFamily: string): void {
+    state.selected = fontFamily;
+    input.value = "";
+    input.placeholder = getDisplayName(fontFamily);
+
+    // Preview selected font in the input
+    if (fontFamily) {
+      input.style.fontFamily = `"${sanitizeFontName(fontFamily)}", sans-serif`;
+    } else {
+      input.style.fontFamily = "";
+    }
+
+    closeDropdown();
+    onFontChange(fontFamily);
+  }
+
+  function scrollToSelected(): void {
+    const idx = state.filtered.indexOf(state.selected);
+    if (idx >= 0) {
+      const items = dropdown.querySelectorAll(".font-selector-item");
+      (items[idx] as HTMLElement)?.scrollIntoView({ block: "center" });
+    }
+  }
+
+  function scrollToHighlight(): void {
+    if (state.highlightIndex < 0) return;
+    const items = dropdown.querySelectorAll(".font-selector-item");
+    const item = items[state.highlightIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }
+
+  // --- Event Handlers ---
+
+  function onInput(): void {
+    updateFiltered(input.value);
+    renderDropdown();
+    if (!state.isOpen) openDropdown();
+  }
+
+  function onFocus(): void {
+    updateFiltered(input.value);
+    openDropdown();
+    input.select();
+  }
+
+  function onBlur(): void {
+    // Delay to allow mousedown on dropdown item
+    setTimeout(() => {
+      closeDropdown();
+      // Reset input to show selected font name
+      input.value = "";
+    }, 150);
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (!state.isOpen && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      openDropdown();
+      e.preventDefault();
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        state.highlightIndex = Math.min(
+          state.highlightIndex + 1,
+          state.filtered.length - 1,
+        );
+        renderDropdown();
+        scrollToHighlight();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        state.highlightIndex = Math.max(state.highlightIndex - 1, 0);
+        renderDropdown();
+        scrollToHighlight();
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (state.highlightIndex >= 0 && state.highlightIndex < state.filtered.length) {
+          selectFont(state.filtered[state.highlightIndex]);
+        } else if (state.filtered.length > 0) {
+          selectFont(state.filtered[0]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        closeDropdown();
+        input.value = "";
+        input.blur();
+        break;
+    }
+  }
+
+  // Close dropdown when clicking outside
+  function onDocumentClick(e: MouseEvent): void {
+    if (!wrapper.contains(e.target as Node)) {
+      closeDropdown();
+      input.value = "";
+    }
+  }
+
+  input.addEventListener("input", onInput);
+  input.addEventListener("focus", onFocus);
+  input.addEventListener("blur", onBlur);
+  input.addEventListener("keydown", onKeydown);
+  document.addEventListener("click", onDocumentClick);
+
+  // --- Public API ---
+
+  return {
+    setFonts(fonts: string[]) {
+      state.fonts = fonts;
+      updateFiltered("");
+    },
+
+    setSelected(fontFamily: string) {
+      state.selected = fontFamily;
+      input.value = "";
+      input.placeholder = getDisplayName(fontFamily);
+      if (fontFamily) {
+        input.style.fontFamily = `"${sanitizeFontName(fontFamily)}", sans-serif`;
+      } else {
+        input.style.fontFamily = "";
+      }
+    },
+
+    getSelected() {
+      return state.selected;
+    },
+
+    destroy() {
+      input.removeEventListener("input", onInput);
+      input.removeEventListener("focus", onFocus);
+      input.removeEventListener("blur", onBlur);
+      input.removeEventListener("keydown", onKeydown);
+      document.removeEventListener("click", onDocumentClick);
+      wrapper.remove();
+    },
+  };
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -48,6 +48,7 @@ import { setupTocSidebar, updateTocFromEditor } from "./toc-sidebar";
 import { HeadingCollapse, collapsePluginKey, getCollapsedHeadings, setCollapsedHeadings } from "./heading-collapse-plugin";
 import { CodeBlockEnhancement } from "./code-block-plugin";
 import { SearchPlugin, performSearch, clearSearch, searchNext, searchPrev, getMatchInfo } from "./search-plugin";
+import { initFontSelector, type FontSelectorAPI, sanitizeFontName } from "./font-selector";
 
 // Fix: @tiptap/markdown v3.19.0 drops `escape` tokens from marked parser,
 // causing escaped characters like \_ to be silently lost during roundtrip.
@@ -132,6 +133,7 @@ const CodeExitHandler = Extension.create({
 
 interface WebviewState {
   theme?: string;
+  fontFamily?: string;
   tocVisible?: boolean;
   collapsedHeadings?: string[];
 }
@@ -687,6 +689,21 @@ function viewSource(): void {
   vscode.postMessage({ type: "viewSource" });
 }
 
+// Font selector instance
+let fontSelector: FontSelectorAPI | null = null;
+
+/** Apply font family override on editor content (empty = use theme default) */
+function applyFontFamily(fontFamily: string): void {
+  const tiptapEl = document.querySelector(".tiptap") as HTMLElement | null;
+  if (tiptapEl) {
+    if (fontFamily) {
+      tiptapEl.style.setProperty("--crepe-font-default", `"${sanitizeFontName(fontFamily)}", sans-serif`);
+    } else {
+      tiptapEl.style.removeProperty("--crepe-font-default");
+    }
+  }
+}
+
 function applyFontSize(size: number): void {
   if (!Number.isFinite(size) || size < 8 || size > 32) return;
   const scaleFactor = size / 16;
@@ -1201,6 +1218,17 @@ function setupToolbarHandlers(): void {
 
   getSourceBtn()?.addEventListener("click", viewSource);
 
+  // Font selector
+  const fontContainer = document.getElementById("font-selector-container");
+  if (fontContainer) {
+    fontSelector?.destroy();
+    fontSelector = initFontSelector(fontContainer, (fontFamily) => {
+      applyFontFamily(fontFamily);
+      vscode.setState({ ...vscode.getState(), fontFamily });
+      vscode.postMessage({ type: "fontChange", font: fontFamily });
+    });
+  }
+
   // Formatting buttons
   document.addEventListener("click", (e) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.toolbar-btn[data-command]');
@@ -1327,7 +1355,13 @@ window.addEventListener("message", async (event) => {
           let justInitialized = false;
           if (!editor) {
             editor = initEditor(displayBody);
-            if (editor) { initTocSidebar(); justInitialized = true; }
+            if (editor) {
+              initTocSidebar();
+              justInitialized = true;
+              // Re-apply font after .tiptap element is created
+              const savedFont = vscode.getState()?.fontFamily;
+              if (savedFont) applyFontFamily(savedFont);
+            }
           } else {
             updateEditorContent(displayBody);
           }
@@ -1400,6 +1434,17 @@ window.addEventListener("message", async (event) => {
       ) {
         globalThemeReceived = message.theme as ThemeName;
         setTheme(globalThemeReceived, false);
+      }
+      break;
+    case "savedFont":
+      if (typeof message.font === "string" && fontSelector) {
+        fontSelector.setSelected(message.font);
+        applyFontFamily(message.font);
+      }
+      break;
+    case "systemFonts":
+      if (Array.isArray(message.fonts) && fontSelector) {
+        fontSelector.setFonts(message.fonts);
       }
       break;
     case "imageSaved":
@@ -1475,6 +1520,10 @@ function init() {
   const savedState = vscode.getState();
   if (savedState?.theme && THEMES.includes(savedState.theme as ThemeName)) {
     setTheme(savedState.theme as ThemeName, false);
+  }
+  // Restore font from webview state (applies immediately, before extension sends savedFont)
+  if (savedState?.fontFamily && typeof savedState.fontFamily === "string") {
+    applyFontFamily(savedState.fontFamily);
   }
 
   window.addEventListener("beforeunload", () => {


### PR DESCRIPTION
## Summary
- Searchable font picker on toolbar — browse all system fonts with live preview
- System font enumeration: macOS (NSFontManager/JXA), Windows (PowerShell), Linux (fc-list)
- Font persists across sessions via globalState; "Default" restores theme font
- Does not affect code font (`--crepe-font-code` untouched)
- CSS injection prevention via `sanitizeFontName()`

## Version
2.7.0

## Files changed
- `src/webview/font-selector.ts` (new) — searchable combobox component
- `src/markdownEditorProvider.ts` — font enum, messaging, HTML/CSS
- `src/webview/main.ts` — integration, state persistence
- `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `package.json`

## Test plan
- [ ] Open .md file, verify font selector appears on toolbar before theme selector
- [ ] Click font selector, verify dropdown shows system fonts with live preview
- [ ] Type to search/filter fonts
- [ ] Select a font, verify editor text changes (code blocks unaffected)
- [ ] Select "Default", verify editor reverts to theme font
- [ ] Switch theme, verify font override persists
- [ ] Close and reopen file, verify font selection is restored
- [ ] Keyboard navigation: Arrow keys, Enter, Escape