### PR TITLE
fix: font selector persistence across file switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## \[2.7.1] - 2026-04-01
+
+### Fixed
+
+* **Font Selector Persistence**: Font selection no longer resets when switching between files — saved font now correctly persists to webview state on restore
+
 ## \[2.7.0] - 2026-04-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1439,6 +1439,7 @@ window.addEventListener("message", async (event) => {
     case "savedFont":
       if (typeof message.font === "string" && fontSelector) {
         fontSelector.setSelected(message.font);
+        vscode.setState({ ...vscode.getState(), fontFamily: message.font });
         applyFontFamily(message.font);
       }
       break;


### PR DESCRIPTION
## Summary
- Fix font selection resetting to default when switching between files
- Root cause: `savedFont` message handler didn't persist to webview state, so re-apply after editor init couldn't find the saved font
- Bump version to 2.7.1

## Changes
- `src/webview/main.ts`: Add `vscode.setState()` call in `savedFont` message handler
- `package.json`: 2.7.0 → 2.7.1
- `CHANGELOG.md`: Add 2.7.1 fix entry

## Test plan
- [ ] Select a custom font in font selector
- [ ] Open a different .md file — font should persist
- [ ] Close and reopen VS Code — font should persist