### PR TITLE
chore: phát hành v2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.2] - 2026-04-13
+
+### Fixed
+
+- **Mermaid SVG Clipping**: Cho phép `foreignObject` label trong mermaid diagram render vượt khỏi bbox (áp dụng `overflow: visible` cho SVG và mọi phần tử con bên trong `.mermaid-svg-host`), khắc phục tình trạng nhãn bị cắt ở mép diagram.
+
 ## [2.8.1] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -2196,6 +2196,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             max-width: 100%;
             height: auto;
           }
+          /* Allow foreignObject labels to render outside their bbox without
+             being clipped by SVG's default overflow:hidden. */
+          .mermaid-svg-host svg,
+          .mermaid-svg-host svg * {
+            overflow: visible;
+          }
           .mermaid-expand-btn {
             position: absolute;
             top: 8px;


### PR DESCRIPTION
## Summary
- Bump version lên **2.8.2**
- Fix mermaid SVG bị cắt nhãn `foreignObject`: áp `overflow: visible` cho `.mermaid-svg-host svg` và mọi phần tử con

## Test plan
- [ ] Mở file `.md` chứa mermaid diagram có label dài
- [ ] Xác nhận label không còn bị cắt ở mép
- [ ] Fullscreen lightbox vẫn hoạt động bình thường

🤖 Generated with [Claude Code](https://claude.com/claude-code)