### PR TITLE
feat(toolbar): content zoom + consolidated Appearance popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.3] - 2026-04-18
+
+### Added
+
+- **Content Zoom**: Zoom editor content 50%–200% (10% step) via Appearance popover or Ctrl/Cmd +/-/0 shortcuts. Only zooms `.tiptap` element — toolbar, TOC, metadata panel stay at native size. Zoom level persisted globally via `context.globalState`.
+- **Appearance Popover**: Consolidated zoom, theme, and font controls into a single popover behind a gear icon on the right side of the toolbar. Prevents toolbar wrapping on narrow viewports (split-view).
+- **View Source Icon**: View Source button changed from text button to `</>` SVG icon using unified `toolbar-btn` class.
+
+### Fixed
+
+- **Popover Dark Theme Contrast**: Input surfaces inside popover now use VS Code native `--vscode-editorWidget-*` variables instead of toolbar glass styling, fixing unreadable controls on dark themes.
+- **Font Selector Escape Propagation**: Added `stopPropagation()` to font dropdown Escape handler, preventing parent popover from closing simultaneously.
+- **Popover Viewport Overflow**: Added `max-width: calc(100vw - 16px)` to prevent popover from overflowing on narrow panels.
+
 ## [2.8.2] - 2026-04-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ npm run package    # Package extension as .vsix
 
 * `pendingEdit` flag prevents edit loops between extension and webview
 
-* Webview persists theme selection and TOC state in `vscode.setState()` (use spread pattern: `{ ...getState(), key: value }`)
+* Webview persists theme, font, zoom, TOC state in `vscode.setState()` (use spread pattern: `{ ...getState(), key: value }`)
 
 * Large files (>500KB) show warning dialog
 
@@ -198,7 +198,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 * Sticky toolbar at top with formatting buttons, heading select, theme select, and View Source
 
-* Buttons grouped by category with separators: Text formatting | Heading | Lists | Blocks | Table & Link | Theme & Source
+* Buttons grouped by category with separators: Text formatting | Heading | Lists | Blocks | Table & Link | Source & Appearance
 
 * Table context buttons (add/delete column/row, delete table) appear only when cursor is inside a table
 
@@ -371,6 +371,50 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 * Mousedown listener attached to `.lightbox-content` so both targets share drag-pan logic
 * Mermaid SVG is sanitized by `mermaid.render()` with `securityLevel: "strict"`, so `innerHTML` assignment is safe for this specific input
 * Mermaid expand button is injected in `mermaid-plugin.ts` widget decoration (top-left of `.mermaid-preview`, hidden on `.mermaid-error` or while editing); click reads `svgEl.outerHTML` from `.mermaid-svg-host` and calls `openMermaidLightbox`
+
+## Content Zoom
+
+**Feature** (in `src/webview/main.ts` + `src/markdownEditorProvider.ts`):
+
+* Zoom range: 50%–200% in 10% steps, applied as CSS `zoom` property on `.tiptap` element only
+* Toolbar, TOC sidebar, metadata panel, Source editor stay at native size (zoom is content-only)
+* Constants: `ZOOM_MIN = 0.5`, `ZOOM_MAX = 2.0`, `ZOOM_STEP = 0.1`, `ZOOM_DEFAULT = 1.0`
+* `clampZoom(value)`: Rounds to 2 decimals (prevents floating-point drift), clamps to min/max
+* `applyZoom(value)`: Sets `style.zoom` on `.tiptap`, updates display button text and disabled states
+* `setZoom(value, persist?)`: Clamp → apply → optionally persist to `vscode.setState()` + notify extension
+
+**Keyboard shortcuts**: `Cmd/Ctrl + =` zoom in, `Cmd/Ctrl + -` zoom out, `Cmd/Ctrl + 0` reset
+
+**Persistence** (dual path, same pattern as font selector):
+
+1. `vscode.setState({ zoomLevel })` — survives tab switches (webview state)
+2. `context.globalState.update("markdownEditorZoom", zoom)` — survives restarts (extension state)
+3. On init: restore from webview state first (immediate), then extension sends `savedZoom` message
+4. At zoom 100%: `globalState` key is removed (`undefined`) to keep clean state
+
+**Message types**: `zoomChange` (webview → extension), `savedZoom` (extension → webview)
+
+**Coordinate safety**: CSS `zoom` in Chromium is transparent to JS coordinate APIs (`getBoundingClientRect`, `clientX/Y`, `elementFromPoint` all operate in viewport coordinate space). Plugins using `posAtCoords`, table context menu, image edit — all verified safe because dropdown/overlay elements are appended to `#editor-container` (parent of `.tiptap`, not zoomed).
+
+## Appearance Popover
+
+**UI** (in `src/markdownEditorProvider.ts` HTML + CSS):
+
+* Gear icon button (`#btn-appearance`) with `aria-haspopup="true"` toggles `#appearance-popover`
+* Popover contains three rows: Zoom controls, Theme select, Font selector (grid layout: 60px label + 1fr control)
+* Positioned `absolute`, `top: calc(100% + 8px)`, `right: 0`, `z-index: 1000`
+* Background uses VS Code native `--vscode-editorWidget-*` variables (not toolbar glass styling) for theme-aware contrast
+* Input surfaces inside popover override with `rgba(127, 127, 127, 0.15)` neutral tint (works for both light & dark)
+* `max-width: calc(100vw - 16px)` prevents overflow on narrow viewports
+
+**Interaction** (in `src/webview/main.ts`):
+
+* Toggle: click `#btn-appearance` → open/close with `is-active` class
+* Close: click outside (document click listener), Escape key (returns focus to gear button)
+* `stopPropagation` on popover clicks prevents close-on-click-inside
+* Font selector Escape handler includes `stopPropagation()` to prevent closing popover when only closing dropdown
+
+**View Source button**: Moved to standalone `toolbar-btn` with `</>` SVG icon (replaces old `.view-source-btn` text button)
 
 ## Toolbar Auto-hide
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 - **Table Editing**: Resizable tables with multi-line cell content (lists, breaks) preserved in markdown
 - **Table Context Menu**: Right-click on table cells for select/add/delete row/column/table actions
 - **Cell Selection Highlight**: Drag-selecting across table cells shows visual highlight overlay
+- **Content Zoom**: Zoom editor content 50%–200% via Appearance popover or Ctrl/Cmd +/-/0 shortcuts
+- **Appearance Popover**: Consolidated zoom, theme, and font controls behind a single gear icon
 - **Theme Selection**: 12 editor themes including Catppuccin (4 variants), Paper (warm serif), Midnight (deep navy)
 - **Image Lightbox**: Fullscreen image viewer with zoom controls (0.5x–4x), expand button on hover
 - **Search (Cmd+F)**: Find text in editor with match highlighting, next/prev navigation, and match counter

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^3.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "2.5.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "2.5.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1490,6 +1490,10 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           .appearance-popover #font-selector-container .font-selector {
             width: 100%;
           }
+          .appearance-popover .font-selector-input::placeholder {
+            color: inherit;
+            opacity: 0.7;
+          }
           .appearance-popover .font-selector-dropdown {
             background: var(--vscode-editorWidget-background, #252526);
             color: var(--vscode-editorWidget-foreground, #cccccc);

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1440,6 +1440,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             right: 0;
             z-index: 1000;
             min-width: 280px;
+            max-width: calc(100vw - 16px);
             padding: 14px;
             background: var(--vscode-editorWidget-background, var(--vscode-menu-background, #252526));
             color: var(--vscode-editorWidget-foreground, var(--vscode-foreground, #cccccc));

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -441,6 +441,16 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 font: savedFont,
               });
             }
+            // Send saved zoom
+            const savedZoom = this.context.globalState.get<number>(
+              "markdownEditorZoom",
+            );
+            if (typeof savedZoom === "number") {
+              webviewPanel.webview.postMessage({
+                type: "savedZoom",
+                zoom: savedZoom,
+              });
+            }
             sendTheme();
             sendConfig();
             updateWebview();
@@ -486,6 +496,21 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               await this.context.globalState.update(
                 "markdownEditorFont",
                 font || undefined, // Remove key when "Default"
+              );
+            }
+            break;
+          }
+          case "zoomChange": {
+            const zoom = (msg as { zoom?: number }).zoom;
+            if (
+              typeof zoom === "number" &&
+              Number.isFinite(zoom) &&
+              zoom >= 0.5 &&
+              zoom <= 2.0
+            ) {
+              await this.context.globalState.update(
+                "markdownEditorZoom",
+                zoom === 1 ? undefined : zoom, // Remove key when back to 100%
               );
             }
             break;
@@ -1347,20 +1372,151 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             font-style: italic;
           }
           .toolbar-spacer { flex: 1; }
-          .view-source-btn {
-            padding: 4px 10px;
-            background: rgba(var(--border-rgb, 0, 0, 0), 0.05);
-            border: 1px solid rgba(var(--border-rgb, 0, 0, 0), 0.1);
+
+          .zoom-controls {
+            display: inline-flex;
+            align-items: center;
+            gap: 0;
+            height: 30px;
+          }
+          .zoom-btn {
+            width: 24px;
+            height: 24px;
+            padding: 0;
+            background: transparent;
+            border: none;
+            border-radius: 4px;
+            color: inherit;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.15s ease-out, transform 0.1s ease-out;
+          }
+          .zoom-btn svg {
+            width: 14px;
+            height: 14px;
+            fill: none;
+            stroke: currentColor;
+            stroke-width: 2;
+            stroke-linecap: round;
+          }
+          .zoom-btn:hover {
+            background: rgba(var(--border-rgb, 0, 0, 0), 0.12);
+          }
+          .zoom-btn:active {
+            transform: scale(0.92);
+          }
+          .zoom-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+          }
+          .zoom-display-btn {
+            min-width: 36px;
+            height: 24px;
+            padding: 0 4px;
+            background: transparent;
+            border: none;
             color: inherit;
             font-size: 11px;
             font-weight: 500;
+            font-variant-numeric: tabular-nums;
             cursor: pointer;
-            border-radius: 6px;
-            height: 30px;
-            transition: background-color 0.15s ease-out, color 0.15s ease-out;
+            border-radius: 4px;
+            transition: background-color 0.15s ease-out;
           }
-          .view-source-btn:hover {
-            background: rgba(var(--border-rgb, 0, 0, 0), 0.1);
+          .zoom-display-btn:hover {
+            background: rgba(var(--border-rgb, 0, 0, 0), 0.12);
+          }
+
+          .appearance-group {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+          }
+          .appearance-popover {
+            position: absolute;
+            top: calc(100% + 8px);
+            right: 0;
+            z-index: 1000;
+            min-width: 280px;
+            padding: 14px;
+            background: var(--vscode-editorWidget-background, var(--vscode-menu-background, #252526));
+            color: var(--vscode-editorWidget-foreground, var(--vscode-foreground, #cccccc));
+            border: 1px solid var(--vscode-editorWidget-border, var(--vscode-menu-border, rgba(127, 127, 127, 0.3)));
+            border-radius: 10px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+          }
+          .appearance-popover.hidden {
+            display: none;
+          }
+          .appearance-popover .appearance-row {
+            display: grid;
+            grid-template-columns: 60px 1fr;
+            align-items: center;
+            gap: 10px;
+          }
+          .appearance-popover .appearance-label {
+            font-size: 11px;
+            font-weight: 600;
+            opacity: 0.85;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: inherit;
+          }
+          /* Override input surfaces inside popover — need high contrast against editorWidget bg,
+             not the toolbar's glass bg. Uses neutral gray tint that works for both light & dark. */
+          .appearance-popover #theme-select,
+          .appearance-popover .font-selector-input {
+            width: 100%;
+            background-color: rgba(127, 127, 127, 0.15);
+            border: 1px solid rgba(127, 127, 127, 0.25);
+            color: inherit;
+          }
+          .appearance-popover #theme-select:hover,
+          .appearance-popover .font-selector-input:hover {
+            background-color: rgba(127, 127, 127, 0.22);
+          }
+          .appearance-popover #theme-select:focus,
+          .appearance-popover .font-selector-input:focus {
+            border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.6);
+            outline: none;
+          }
+          .appearance-popover #font-selector-container,
+          .appearance-popover #font-selector-container .font-selector {
+            width: 100%;
+          }
+          .appearance-popover .font-selector-dropdown {
+            background: var(--vscode-editorWidget-background, #252526);
+            color: var(--vscode-editorWidget-foreground, #cccccc);
+            border-color: var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3));
+          }
+          /* Zoom row inside popover — compact trio */
+          .appearance-popover .zoom-controls {
+            justify-content: flex-start;
+            gap: 4px;
+          }
+          .appearance-popover .zoom-btn {
+            width: 28px;
+            height: 28px;
+            background: rgba(127, 127, 127, 0.15);
+          }
+          .appearance-popover .zoom-btn:hover:not(:disabled) {
+            background: rgba(127, 127, 127, 0.28);
+          }
+          .appearance-popover .zoom-display-btn {
+            min-width: 48px;
+            height: 28px;
+            background: rgba(127, 127, 127, 0.1);
+          }
+          .appearance-popover .zoom-display-btn:hover {
+            background: rgba(127, 127, 127, 0.22);
+          }
+          #btn-appearance.is-active {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.18);
           }
 
           #editor-container {
@@ -2865,7 +3021,6 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           #editor-container:hover #word-count { opacity: 0.6; }
           /* Focus indicators */
           .toolbar-btn:focus-visible,
-          .view-source-btn:focus-visible,
           #heading-select:focus-visible,
           #theme-select:focus-visible,
           .toc-toggle-btn:focus-visible,
@@ -3027,24 +3182,51 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
           <div class="toolbar-spacer"></div>
 
-          <!-- Font, Theme & View Source (right side) -->
-          <div class="toolbar-group" style="gap: 6px;">
-            <div id="font-selector-container"></div>
-            <select id="theme-select" aria-label="Editor theme">
-              <option value="frame">Frame</option>
-              <option value="frame-dark">Frame Dark</option>
-              <option value="nord">Nord</option>
-              <option value="nord-dark">Nord Dark</option>
-              <option value="crepe">Crepe</option>
-              <option value="crepe-dark">Crepe Dark</option>
-              <option value="catppuccin-latte">Catppuccin Latte</option>
-              <option value="catppuccin-frappe">Catppuccin Frappé</option>
-              <option value="catppuccin-macchiato">Catppuccin Macchiato</option>
-              <option value="catppuccin-mocha">Catppuccin Mocha</option>
-              <option value="paper">Paper</option>
-              <option value="midnight">Midnight</option>
-            </select>
-            <button id="btn-source" class="view-source-btn" aria-label="View source in text editor">Source</button>
+          <!-- Appearance popover + Source (right side) -->
+          <div class="toolbar-group" style="gap: 4px;">
+            <button id="btn-source" class="toolbar-btn" title="View Source (open raw .md in text editor)" aria-label="View source">
+              <svg viewBox="0 0 24 24"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/><line x1="14.5" y1="4" x2="9.5" y2="20"/></svg>
+            </button>
+            <div class="appearance-group">
+              <button id="btn-appearance" class="toolbar-btn" title="Appearance (zoom, theme, font)" aria-label="Appearance" aria-haspopup="true" aria-expanded="false">
+                <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+              </button>
+              <div id="appearance-popover" class="appearance-popover hidden" role="menu" aria-label="Appearance settings">
+                <div class="appearance-row">
+                  <label class="appearance-label">Zoom</label>
+                  <div id="zoom-controls" class="zoom-controls" role="group" aria-label="Zoom">
+                    <button id="btn-zoom-out" class="zoom-btn" title="Zoom Out (Ctrl/Cmd -)" aria-label="Zoom out">
+                      <svg viewBox="0 0 24 24"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    </button>
+                    <button id="btn-zoom-reset" class="zoom-display-btn" title="Reset Zoom (Ctrl/Cmd 0)" aria-label="Reset zoom">100%</button>
+                    <button id="btn-zoom-in" class="zoom-btn" title="Zoom In (Ctrl/Cmd +)" aria-label="Zoom in">
+                      <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    </button>
+                  </div>
+                </div>
+                <div class="appearance-row">
+                  <label class="appearance-label" for="theme-select">Theme</label>
+                  <select id="theme-select" aria-label="Editor theme">
+                    <option value="frame">Frame</option>
+                    <option value="frame-dark">Frame Dark</option>
+                    <option value="nord">Nord</option>
+                    <option value="nord-dark">Nord Dark</option>
+                    <option value="crepe">Crepe</option>
+                    <option value="crepe-dark">Crepe Dark</option>
+                    <option value="catppuccin-latte">Catppuccin Latte</option>
+                    <option value="catppuccin-frappe">Catppuccin Frappé</option>
+                    <option value="catppuccin-macchiato">Catppuccin Macchiato</option>
+                    <option value="catppuccin-mocha">Catppuccin Mocha</option>
+                    <option value="paper">Paper</option>
+                    <option value="midnight">Midnight</option>
+                  </select>
+                </div>
+                <div class="appearance-row">
+                  <label class="appearance-label">Font</label>
+                  <div id="font-selector-container"></div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div id="search-bar" class="hidden">

--- a/src/webview/font-selector.ts
+++ b/src/webview/font-selector.ts
@@ -168,6 +168,7 @@ export function initFontSelector(
     }
 
     closeDropdown();
+    input.blur();
     onFontChange(fontFamily);
   }
 

--- a/src/webview/font-selector.ts
+++ b/src/webview/font-selector.ts
@@ -242,6 +242,7 @@ export function initFontSelector(
         break;
       case "Escape":
         e.preventDefault();
+        e.stopPropagation();
         closeDropdown();
         input.value = "";
         input.blur();

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -135,6 +135,7 @@ const CodeExitHandler = Extension.create({
 interface WebviewState {
   theme?: string;
   fontFamily?: string;
+  zoomLevel?: number;
   tocVisible?: boolean;
   collapsedHeadings?: string[];
 }
@@ -792,6 +793,48 @@ function applyFontFamily(fontFamily: string): void {
   }
 }
 
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 2.0;
+const ZOOM_STEP = 0.1;
+const ZOOM_DEFAULT = 1.0;
+let currentZoom = ZOOM_DEFAULT;
+
+function clampZoom(value: number): number {
+  if (!Number.isFinite(value)) return ZOOM_DEFAULT;
+  // Round to 2 decimals to avoid floating-point drift (e.g. 0.1 + 0.1 + 0.1 !== 0.3)
+  const rounded = Math.round(value * 100) / 100;
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, rounded));
+}
+
+/** Apply zoom scale to editor content only (the .tiptap element). */
+function applyZoom(value: number): void {
+  const tiptapEl = document.querySelector(".tiptap") as HTMLElement | null;
+  if (tiptapEl) {
+    if (value === ZOOM_DEFAULT) {
+      tiptapEl.style.removeProperty("zoom");
+    } else {
+      tiptapEl.style.zoom = String(value);
+    }
+  }
+  const display = document.getElementById("btn-zoom-reset");
+  if (display) display.textContent = `${Math.round(value * 100)}%`;
+  const outBtn = document.getElementById("btn-zoom-out") as HTMLButtonElement | null;
+  const inBtn = document.getElementById("btn-zoom-in") as HTMLButtonElement | null;
+  if (outBtn) outBtn.disabled = value <= ZOOM_MIN;
+  if (inBtn) inBtn.disabled = value >= ZOOM_MAX;
+}
+
+/** Set zoom level, persist to state, notify extension. */
+function setZoom(value: number, persist = true): void {
+  const next = clampZoom(value);
+  currentZoom = next;
+  applyZoom(next);
+  if (persist) {
+    vscode.setState({ ...vscode.getState(), zoomLevel: next });
+    vscode.postMessage({ type: "zoomChange", zoom: next });
+  }
+}
+
 function applyFontSize(size: number): void {
   if (!Number.isFinite(size) || size < 8 || size > 32) return;
   const scaleFactor = size / 16;
@@ -1356,6 +1399,67 @@ function setupToolbarHandlers(): void {
     });
   }
 
+  // Appearance popover (theme / font / source)
+  const appearanceBtn = document.getElementById("btn-appearance");
+  const appearancePopover = document.getElementById("appearance-popover");
+  if (appearanceBtn && appearancePopover) {
+    const closePopover = () => {
+      appearancePopover.classList.add("hidden");
+      appearanceBtn.classList.remove("is-active");
+      appearanceBtn.setAttribute("aria-expanded", "false");
+    };
+    const openPopover = () => {
+      appearancePopover.classList.remove("hidden");
+      appearanceBtn.classList.add("is-active");
+      appearanceBtn.setAttribute("aria-expanded", "true");
+    };
+    appearanceBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (appearancePopover.classList.contains("hidden")) {
+        openPopover();
+      } else {
+        closePopover();
+      }
+    });
+    // Click outside → close. Clicks inside the popover don't bubble past it.
+    appearancePopover.addEventListener("click", (e) => e.stopPropagation());
+    document.addEventListener("click", () => {
+      if (!appearancePopover.classList.contains("hidden")) closePopover();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !appearancePopover.classList.contains("hidden")) {
+        closePopover();
+        appearanceBtn.focus();
+      }
+    });
+  }
+
+  // Zoom controls
+  document.getElementById("btn-zoom-out")?.addEventListener("click", () => {
+    setZoom(currentZoom - ZOOM_STEP);
+  });
+  document.getElementById("btn-zoom-in")?.addEventListener("click", () => {
+    setZoom(currentZoom + ZOOM_STEP);
+  });
+  document.getElementById("btn-zoom-reset")?.addEventListener("click", () => {
+    setZoom(ZOOM_DEFAULT);
+  });
+  // Keyboard shortcuts: Cmd/Ctrl + = / - / 0
+  document.addEventListener("keydown", (e) => {
+    if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+    // "=" and "+" share a physical key; accept both. NumpadAdd / NumpadSubtract too.
+    if (e.key === "=" || e.key === "+") {
+      e.preventDefault();
+      setZoom(currentZoom + ZOOM_STEP);
+    } else if (e.key === "-" || e.key === "_") {
+      e.preventDefault();
+      setZoom(currentZoom - ZOOM_STEP);
+    } else if (e.key === "0") {
+      e.preventDefault();
+      setZoom(ZOOM_DEFAULT);
+    }
+  });
+
   // Formatting buttons
   document.addEventListener("click", (e) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.toolbar-btn[data-command]');
@@ -1489,6 +1593,8 @@ window.addEventListener("message", async (event) => {
               // Re-apply font after .tiptap element is created
               const savedFont = vscode.getState()?.fontFamily;
               if (savedFont) applyFontFamily(savedFont);
+              // Re-apply zoom after .tiptap element is created
+              applyZoom(currentZoom);
             }
           } else {
             updateEditorContent(displayBody);
@@ -1572,6 +1678,13 @@ window.addEventListener("message", async (event) => {
         fontSelector.setSelected(message.font);
         vscode.setState({ ...vscode.getState(), fontFamily: message.font });
         applyFontFamily(message.font);
+      }
+      break;
+    case "savedZoom":
+      if (typeof message.zoom === "number") {
+        // Persist=false — this came from extension, no need to echo back
+        setZoom(message.zoom, false);
+        vscode.setState({ ...vscode.getState(), zoomLevel: currentZoom });
       }
       break;
     case "systemFonts":
@@ -1663,6 +1776,13 @@ function init() {
   // Restore font from webview state (applies immediately, before extension sends savedFont)
   if (savedState?.fontFamily && typeof savedState.fontFamily === "string") {
     applyFontFamily(savedState.fontFamily);
+  }
+  // Restore zoom from webview state (applies immediately, before extension sends savedZoom)
+  if (typeof savedState?.zoomLevel === "number") {
+    setZoom(savedState.zoomLevel, false);
+  } else {
+    // Still initializes display + disabled states to 100%
+    applyZoom(ZOOM_DEFAULT);
   }
 
   window.addEventListener("beforeunload", () => {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1339,7 +1339,8 @@ function setupToolbarAutoHide(autoHide: boolean): void {
     if (isHovering) return;
     if (hideTimeout) clearTimeout(hideTimeout);
     hideTimeout = setTimeout(() => {
-      if (!isHovering) toolbar.classList.add("toolbar-hidden");
+      const popoverOpen = !document.getElementById("appearance-popover")?.classList.contains("hidden");
+      if (!isHovering && !popoverOpen) toolbar.classList.add("toolbar-hidden");
     }, 3000);
   };
 
@@ -1434,6 +1435,8 @@ function setupToolbarHandlers(): void {
     });
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape" && !appearancePopover.classList.contains("hidden")) {
+        e.preventDefault();
+        e.stopPropagation();
         closePopover();
         appearanceBtn.focus();
       }
@@ -1453,6 +1456,7 @@ function setupToolbarHandlers(): void {
   // Keyboard shortcuts: Cmd/Ctrl + = / - / 0
   document.addEventListener("keydown", (e) => {
     if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+    if (document.getElementById("lightbox-overlay")?.classList.contains("active")) return;
     // "=" and "+" share a physical key; accept both. NumpadAdd / NumpadSubtract too.
     if (e.key === "=" || e.key === "+") {
       e.preventDefault();

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1413,18 +1413,24 @@ function setupToolbarHandlers(): void {
       appearanceBtn.classList.add("is-active");
       appearanceBtn.setAttribute("aria-expanded", "true");
     };
-    appearanceBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
+    appearanceBtn.addEventListener("click", () => {
       if (appearancePopover.classList.contains("hidden")) {
         openPopover();
       } else {
         closePopover();
       }
     });
-    // Click outside → close. Clicks inside the popover don't bubble past it.
-    appearancePopover.addEventListener("click", (e) => e.stopPropagation());
-    document.addEventListener("click", () => {
-      if (!appearancePopover.classList.contains("hidden")) closePopover();
+    // Close on mousedown outside popover. mousedown fires on the actual pressed
+    // element, avoiding false closes from native <select> dropdowns and font
+    // selector items that hide on mousedown before click can propagate.
+    document.addEventListener("mousedown", (e) => {
+      if (
+        !appearancePopover.classList.contains("hidden") &&
+        !appearancePopover.contains(e.target as Node) &&
+        !appearanceBtn.contains(e.target as Node)
+      ) {
+        closePopover();
+      }
     });
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape" && !appearancePopover.classList.contains("hidden")) {


### PR DESCRIPTION
Adds a content-only zoom control (50%–200%, 10% step) with keyboard shortcuts Ctrl/Cmd +/-/0. Zoom level is persisted globally via context.globalState under "markdownEditorZoom" and applied as the `zoom` CSS property on the .tiptap element — toolbar, TOC sidebar, metadata panel, and the Source editor stay at their native size.

The right side of the toolbar is consolidated behind a single Appearance gear icon (zoom, theme, font) to prevent wrapping on narrow viewports such as split-view. View Source becomes a compact </> icon next to the gear, using the standard toolbar-btn style.

Popover inputs use VS Code's native --vscode-editorWidget-* variables for theme-aware floating-panel contrast, fixing unreadable controls on dark themes where the previous toolbar-glass styling (rgba(--border-rgb, 0.05)) disappeared against the solid popover background.

<img width="779" height="246" alt="image" src="https://github.com/user-attachments/assets/5f4c8fa2-dea4-4fa7-9c1b-5ed7100e8fc8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content zoom (50%–200%, 10% steps) with in/out/reset controls and Cmd/Ctrl +, -, 0 shortcuts
  * Appearance popover (gear) consolidating zoom, theme, and font controls; editor zoom persisted across sessions
  * View Source moved to a compact toolbar icon

* **Bug Fixes / UI**
  * Improved popover behavior, dark-theme contrast, and Escape/interaction handling for font dropdown
<!-- end of auto-generated comment: release notes by coderabbit.ai -->