### PR TITLE
fix: loại file dev thừa khỏi extension package (v2.8.4)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,14 +1,38 @@
-.vscode/**
+# Source & build config
 src/**
-node_modules/**
 *.ts
 tsconfig.json
 esbuild.config.js
-.gitignore
-.git/**
-.claude/**
-plans/**
-docs/**
-CLAUDE.md
+
+# Dependencies
+node_modules/**
 package-lock.json
+
+# Git & CI
+.git/**
+.github/**
+.gitignore
+.gitnexus/**
+.gitnexusignore
+
+# AI/agent tools
+.agent/**
+.claude/**
+.mcp.json
+_bmad/**
+_bmad-output/**
+AGENTS.md
+CLAUDE.md
+skills-lock.json
+
+# IDE
+.vscode/**
+.vscodeignore
+
+# Docs & plans
+docs/**
+plans/**
+
+# Build artifacts
 *.vsix
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.4] - 2026-04-18
+
+### Fixed
+
+- **Loại file thừa trong package**: Cập nhật `.vscodeignore` để loại bỏ file dev (`.agent`, `.github`, `.mcp.json`, `_bmad`, `AGENTS.md`, `.gitnexus`, `skills-lock.json`, `.DS_Store`) khỏi extension package. Giảm kích thước package và dọn sạch nội dung không cần thiết.
+
 ## [2.8.3] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- Cập nhật `.vscodeignore` để exclude toàn bộ file dev/AI tools (`.agent`, `.github`, `.mcp.json`, `_bmad`, `AGENTS.md`, `.gitnexus`, `skills-lock.json`, `.DS_Store`) khỏi extension package
- Bump version 2.8.3 → 2.8.4

## Test plan
- [x] `vsce package` tạo package 14 files, không chứa file dev
- [x] Package chỉ chứa: `package.json`, `LICENSE.txt`, `README.md`, `CHANGELOG.md`, `out/`, `media/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)