### PR TITLE
Release v2.8.5: copy mermaid diagram as PNG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tui-milkdown-vscode** (405 symbols, 990 relationships, 33 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tui-milkdown-vscode** (496 symbols, 1178 relationships, 41 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.4] - 2026-04-22
+
+### Added
+
+- **Copy Mermaid as PNG**: Nút "copy" xuất hiện trên mermaid preview khi hover (cạnh nút expand) và trong lightbox toolbar. Click sẽ render SVG sang PNG bitmap (scale 2x cho retina) rồi ghi vào clipboard bằng `navigator.clipboard.write` + `ClipboardItem("image/png")`. Dán được trực tiếp vào Slack, Word, Figma, Notion, Preview.app. Feedback checkmark 1.5s khi thành công, VS Code warning dialog khi lỗi. Nút tự ẩn trên `.mermaid-error`, mode editing, và lightbox mode ảnh thường.
+
 ## [2.8.3] - 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -860,7 +860,7 @@ After every development cycle (new feature, bug fix, refactor), update these fil
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tui-milkdown-vscode** (405 symbols, 990 relationships, 33 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tui-milkdown-vscode** (496 symbols, 1178 relationships, 41 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ src/
     ├── code-block-plugin.ts  # Code block header: language badge dropdown + copy button
     ├── image-edit-plugin.ts  # Double-click image URL editing + expand button
     ├── image-lightbox-plugin.ts # Fullscreen image viewer with zoom controls (0.5x-4x)
+    ├── svg-to-png.ts         # SVG → PNG blob via canvas + clipboard.write (mermaid copy helper)
     ├── table-markdown-serializer.ts # Custom GFM table serializer (multi-line cells)
     ├── table-cell-content-parser.ts # Post-parse transformer for table cell lists/breaks
     ├── table-context-menu.ts # Right-click context menu for table operations
@@ -703,9 +704,34 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 * **Fullscreen expand**: Widget decoration contains `.mermaid-svg-host` (SVG target for `innerHTML`) + `.mermaid-expand-btn` sibling (top-left, hover fade-in, hidden on error/editing). Click reads `svgEl.outerHTML` and calls `openMermaidLightbox()`
 
-**CSS classes**: `.mermaid-code-block`, `.mermaid-editing`, `.mermaid-preview`, `.mermaid-svg-host`, `.mermaid-error`, `.mermaid-expand-btn`
+**CSS classes**: `.mermaid-code-block`, `.mermaid-editing`, `.mermaid-preview`, `.mermaid-svg-host`, `.mermaid-error`, `.mermaid-expand-btn`, `.mermaid-copy-btn`
 
 **Dependencies**: `mermaid@^11.12.2`
+
+## Mermaid Copy as PNG
+
+**Module** (`src/webview/svg-to-png.ts`):
+* `svgToPngBlob(svgString, scale = 2)`: DOMParser → ensure `width`/`height` (fallback to `viewBox`) → Blob SVG → `URL.createObjectURL` → `<Image>` → `canvas.drawImage` at `native * scale` → `canvas.toBlob('image/png')`. Scale qua canvas (không qua CSS) đảm bảo PNG nét mọi dpi.
+* `copyPngBlobToClipboard(blob)`: `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])`. Throws nếu `ClipboardItem` hoặc `clipboard.write` unavailable.
+* `reportCopyError(message)`: Dispatch `CustomEvent('mermaid-copy-error', { detail: { message } })` trên `document`. Module giữ decoupled với vscode API handle.
+
+**Preview button** (`src/webview/mermaid-plugin.ts`):
+* `.mermaid-copy-btn` injected cạnh `.mermaid-expand-btn` trong widget decoration (cùng vòng tạo button). Click: query `svg` trong `.mermaid-svg-host` → `svgToPngBlob` → `copyPngBlobToClipboard` → `flashCopiedState()` (thêm `.is-copied` 1.5s, 2 `<svg>` icon copy/check toggle qua CSS).
+* Tự ẩn qua CSS khi `.mermaid-error`, `.mermaid-editing`, hoặc chưa `data-rendered="true"`.
+
+**Lightbox button** (`src/webview/image-lightbox-plugin.ts`):
+* `#lightbox-copy` trong `.lightbox-controls` (trước nút close). Wired trong `initLightbox`, toggle hiển thị qua `setCopyButtonVisibility()`:
+  * `openMermaidLightbox` → visible
+  * `openLightbox` (image) và `closeLightbox` → hidden
+* Click đọc SVG từ `#lightbox-svg.querySelector('svg')` → cùng flow với preview.
+
+**Error forwarding** (`src/webview/main.ts`):
+* Listener `document.addEventListener('mermaid-copy-error', ...)` forward `detail.message` tới extension bằng `vscode.postMessage({ type: 'showWarning', message })`. Giữ `svg-to-png.ts` không cần `acquireVsCodeApi()` reference.
+
+**Gotchas**:
+* Lightbox strips `width`/`height` attribute của SVG (để zoom tự do), nhưng `svgToPngBlob` đã normalize qua `resolveSvgSize()` (đọc `viewBox` khi thiếu attr) rồi set lại trước khi serialize.
+* Clipboard requires secure context — VS Code webview đủ điều kiện. Nếu runtime cũ thiếu `ClipboardItem`, button ném lỗi, error được gửi thành VS Code warning dialog.
+* `XMLSerializer` + Blob SVG tránh inline `<script>` → CSP-safe, không cần tweak CSP.
 
 ## GitHub-Style Alerts
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 - **Rich Text Editing**: WYSIWYG markdown editing powered by Tiptap + `@tiptap/markdown` (MarkedJS parser, GFM support)
 - **Syntax Highlighting**: Code blocks with language-aware highlighting via lowlight (19 languages)
 - **Code Block Header**: Language badge with dropdown selector and copy-to-clipboard button
-- **Mermaid Diagrams**: Live SVG preview for `mermaid` code blocks with view/edit mode toggle, theme sync, caching, and fullscreen lightbox with zoom/pan
+- **Mermaid Diagrams**: Live SVG preview for `mermaid` code blocks with view/edit mode toggle, theme sync, caching, fullscreen lightbox (zoom/pan), and copy-as-PNG button (2x retina) on preview + in lightbox toolbar
 - **GitHub-Style Alerts**: `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]` render as color-coded alert boxes
 - **Task Lists**: Checkbox support with nested task items
 - **Table Editing**: Resizable tables with multi-line cell content (lists, breaks) preserved in markdown

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -2,6 +2,11 @@
 
 Findings surfaced incidentally by review but not caused by the triggering story. Pick up later.
 
+## Mermaid copy as PNG — nice-to-have cải thiện
+
+1. **Screen reader feedback cho trạng thái "copied"** — `.mermaid-copy-btn` và `#lightbox-copy` chỉ đổi icon visual khi copy thành công. Nên thêm `aria-live="polite"` region hoặc đổi `aria-label` tạm thành "Copied" trong 1.5s để screen reader thông báo. Surfaced by blind-hunter review spec-mermaid-copy-image.
+2. **Refactor duplicate copy flow** — mermaid-plugin.ts và image-lightbox-plugin.ts cùng implement pattern `svgToPngBlob → copyPngBlobToClipboard → flashCopied → reportCopyError`. Có thể gom thành helper `copySvgAsPng(button, getSvgMarkup)` trong svg-to-png.ts. Surfaced by blind-hunter review spec-mermaid-copy-image.
+
 ## Mermaid plugin — pre-existing issues
 
 1. **Stale lightbox snapshot on doc edit** — If user edits mermaid code while fullscreen lightbox is open, the lightbox keeps showing the snapshot captured at click time. Nice-to-have: close lightbox on `docChanged` when the underlying mermaid block changes, or re-render from the current block.

--- a/_bmad-output/implementation-artifacts/spec-mermaid-copy-image.md
+++ b/_bmad-output/implementation-artifacts/spec-mermaid-copy-image.md
@@ -1,0 +1,114 @@
+---
+title: 'Copy sơ đồ Mermaid ra clipboard dưới dạng PNG'
+type: 'feature'
+created: '2026-04-22'
+status: 'done'
+baseline_commit: 'f1d461bcc727b61704854223385cf53e4753302b'
+context:
+  - '{project-root}/CLAUDE.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Không có cách copy sơ đồ Mermaid ra clipboard để dán vào Slack/Word/Figma. User phải screenshot thủ công, mất nét trên retina.
+
+**Approach:** Thêm nút "copy" ở 2 chỗ: góc trên mermaid preview (cạnh nút expand) và trong lightbox toolbar. Click render SVG sang PNG 2x native qua canvas, ghi clipboard bằng `navigator.clipboard.write` + `ClipboardItem("image/png")`. Feedback: icon đổi checkmark 1.5s.
+
+## Boundaries & Constraints
+
+**Always:**
+- PNG scale cố định 2x SVG native.
+- Snapshot SVG hiện có trong DOM, không re-render từ code.
+- Ẩn nút copy khi preview `.mermaid-error` hoặc `.mermaid-editing`.
+- Trong lightbox, nút copy chỉ hiển thị khi target là mermaid (ẩn khi `<img>`).
+- CSP-safe: canvas + `URL.createObjectURL` blob SVG. Không `eval`, không inject script.
+
+**Ask First:**
+- Nếu `navigator.clipboard.write` / `ClipboardItem` không có trong webview runtime → HALT, xin chỉ đạo.
+
+**Never:** Copy SVG text markup. UI chọn format. Đụng image lightbox. Dọn deferred issue ngoài scope.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Trạng thái | Kết quả | Xử lý lỗi |
+|----------|-----------|---------|-----------|
+| Copy từ preview | SVG render OK trong `.mermaid-svg-host` | PNG 2x vào clipboard, icon ✓ 1.5s | N/A |
+| Copy từ lightbox | Mode mermaid | Giống preview, icon ✓ trên nút lightbox | N/A |
+| Mermaid lỗi/đang edit | class `.mermaid-error` hoặc `.mermaid-editing` | Nút copy ẩn | N/A |
+| Lightbox image mode | `currentTarget` là `<img>` | Nút copy ẩn | N/A |
+| Clipboard reject | Promise fail | Icon khôi phục ngay, gửi `showWarning` tới extension | Không throw |
+| SVG 0px / chưa render | width/height = 0 | Bỏ qua, `showWarning` | Không tạo blob |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `src/webview/svg-to-png.ts` -- MỚI: `svgToPngBlob(svg, scale)` + `copyPngBlobToClipboard(blob)`; canvas + Image + Blob URL.
+- `src/webview/mermaid-plugin.ts` -- Widget (~line 336-356): append `.mermaid-copy-btn` sau `.mermaid-svg-host`.
+- `src/webview/image-lightbox-plugin.ts` -- Thêm `#lightbox-copy` trong `.lightbox-controls`, toggle visibility theo `currentTarget`.
+- `src/markdownEditorProvider.ts` -- HTML `<button id="lightbox-copy">` trong `.lightbox-controls`. CSS `.mermaid-copy-btn` (clone expand-btn, `left: 44px`), icon + state `.is-copied`.
+- `CHANGELOG.md`, `README.md`, `CLAUDE.md` -- Cập nhật sau khi implement.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `src/webview/svg-to-png.ts` -- 2 export: `svgToPngBlob(svgString, scale): Promise<Blob>` đọc viewBox/width/height, vẽ canvas scale×native rồi `toBlob('image/png')`; `copyPngBlobToClipboard(blob): Promise<void>` dùng `ClipboardItem`. Thêm `reportCopyError()` dispatch CustomEvent để forward lên extension.
+- [x] `src/webview/mermaid-plugin.ts` -- Append `.mermaid-copy-btn` trong widget decoration. Click: query `svg` trong host → helper → swap icon 1.5s. Lỗi → `reportCopyError`.
+- [x] `src/webview/image-lightbox-plugin.ts` -- Ref `#lightbox-copy` trong `initLightbox`; helper `setCopyButtonVisibility` toggle trong `openLightbox` (hide), `openMermaidLightbox` (show), `closeLightbox` (hide). Click: lấy SVG từ `svgWrapper` → helper → swap icon. Lỗi → `reportCopyError`.
+- [x] `src/markdownEditorProvider.ts` -- Thêm HTML `<button id="lightbox-copy" class="lightbox-btn lightbox-copy-btn hidden" title="Copy as PNG">` trước nút close. CSS `.mermaid-copy-btn` + `#lightbox-copy` + icon copy/check stroke Lucide + state `.is-copied`.
+- [x] `src/webview/main.ts` -- Listener `mermaid-copy-error` → forward `vscode.postMessage({ type: 'showWarning', message })`.
+- [x] `package.json` -- Bump `2.8.3` → `2.8.4`.
+
+**Acceptance Criteria:**
+- Given mermaid render OK, when click copy trên preview, then clipboard có PNG paste được vào app khác và icon ✓ 1.5s.
+- Given lightbox mở mermaid, when click copy toolbar, then clipboard có PNG giống preview, icon ✓ 1.5s.
+- Given lightbox mở image thường, when nhìn toolbar, then nút copy ẩn.
+- Given mermaid parse lỗi, when nhìn preview, then nút copy ẩn.
+- Given clipboard API reject, when click copy, then icon khôi phục và VS Code hiện warning dialog.
+- Given paste PNG vào viewer, when xem kích thước, then width = `2 × svgNativeWidth`.
+
+## Spec Change Log
+
+### 2026-04-22 — review loop 1 patches
+
+- **Finding (Blind + Edge hunter)**: Stale timer/button reference khi widget bị rebuild mid-copy, promise hang nếu `canvas.toBlob` hoặc `<img>` load không settle, race khi user spam click copy, stale SVG snapshot khi lightbox copy chạm race với doc re-render.
+- **Amendment**:
+  - `svg-to-png.ts`: `LOAD_IMAGE_TIMEOUT_MS` / `TO_BLOB_TIMEOUT_MS` = 5s, bọc `loadImage` và `canvas.toBlob` trong timeout reject.
+  - `mermaid-plugin.ts`: `copyBtn.disabled` gate, snapshot `svgEl.outerHTML` tại click-time, `button.isConnected` guard trong `flashCopiedState` + trước khi remove class.
+  - `image-lightbox-plugin.ts`: đổi signature sang `HTMLButtonElement`, disable gate, snapshot `svgMarkup` tại click, `isConnected` guard cả khi add `.is-copied` lẫn khi remove qua timer.
+- **Known-bad avoided**: copy hang vô thời hạn với SVG lớn hoặc có external reference; stale PNG khi user sửa doc trong lúc clipboard đang ghi; double promise gây `clipboard.write` chồng nhau.
+- **KEEP**: pattern `CustomEvent('mermaid-copy-error')` → `vscode.postMessage({ showWarning })` trong `main.ts` (decouple plugin khỏi vscode handle); 2 `<svg>` icon toggle qua CSS class `.is-copied`.
+- **Deferred**: aria-live cho screen reader feedback, refactor duplicate copy flow giữa 2 plugin. Ghi vào `deferred-work.md`.
+
+### 2026-04-22 — hotfix: blob URL → data URL (bỏ CSP workaround)
+
+- **Finding round 1 (user test)**: `Loading the image 'blob:vscode-webview://...' violates CSP directive: img-src 'self' https: data:`.
+- **Finding round 2 (user test)**: Sau khi thêm `blob:` vào `img-src`, error đổi thành `Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported`.
+- **Root cause**: `blob:` URL trong vscode-webview sandbox cross origin với document canvas → canvas tainted khi drawImage → `toBlob` bị chặn. Cộng với mermaid dùng `<foreignObject>` cho label HTML, Chromium sandbox chính sách nghiêm hơn.
+- **Amendment**: `svg-to-png.ts` bỏ hẳn `Blob` + `URL.createObjectURL` + `revokeObjectURL`. Dùng `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serialized)}` → same-origin với document, không tainted canvas. `markdownEditorProvider.ts` rollback `blob:` khỏi `img-src` CSP (dọn orphan do round 1 thêm).
+- **Known-bad avoided**: Canvas export fail im lặng với SVG mermaid có foreignObject; over-granting `blob:` trong CSP mà không dùng.
+- **KEEP**: Pattern XMLSerializer + `<img>` rasterize + `canvas.toBlob` vẫn là cốt lõi — chỉ URL scheme thay đổi. Timeout guards vẫn giữ nguyên.
+
+## Design Notes
+
+**SVG → PNG (CSP-safe):** Blob SVG → `URL.createObjectURL` → `Image.onload` → `canvas.drawImage` với kích thước `native * scale` → `canvas.toBlob('image/png')`. Scale qua canvas (không qua CSS) để ảnh nét mọi dpi viewer.
+
+**Clipboard:** `navigator.clipboard.write([new ClipboardItem({"image/png": blob})])`.
+
+**Icon swap:** 2 `<svg>` trong button, class `.is-copied` toggle visibility (pattern copy từ `code-block-plugin` đã có).
+
+## Verification
+
+**Commands:**
+- `npm run lint` -- expected: TS pass.
+- `npm run build:dev` -- expected: bundle OK.
+- `npx gitnexus analyze` -- expected: index refresh sau thêm file mới.
+
+**Manual checks:**
+- Mở `.md` có block mermaid, hover preview → thấy 2 nút (copy + expand). Click copy → ✓ 1.5s. Paste Preview.app → ảnh nét, kích thước = 2× viewbox.
+- Click expand → lightbox → thấy nút copy toolbar → click → paste → giống ảnh trên.
+- Click ảnh thường (png/jpg) → lightbox → nút copy ẩn.
+- Mermaid invalid → preview error → nút copy biến mất.
+- Test theme light + dark + Catppuccin Mocha, icon đúng màu CSS var.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -2401,6 +2401,49 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           @media (prefers-reduced-motion: reduce) {
             .mermaid-expand-btn { transition: none; }
           }
+          .mermaid-copy-btn {
+            position: absolute;
+            top: 8px;
+            left: 44px;
+            width: 28px;
+            height: 28px;
+            padding: 0;
+            border: 1px solid var(--crepe-color-outline, rgba(0,0,0,0.15));
+            border-radius: 6px;
+            background: var(--vscode-badge-background, rgba(255,255,255,0.9));
+            color: var(--vscode-badge-foreground, #444);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            transition: opacity 0.15s ease, background 0.15s ease;
+            z-index: 2;
+          }
+          .mermaid-copy-btn svg { width: 14px; height: 14px; }
+          .mermaid-copy-btn .icon-check { display: none; }
+          .mermaid-copy-btn.is-copied .icon-copy { display: none; }
+          .mermaid-copy-btn.is-copied .icon-check {
+            display: inline-flex;
+            color: #2da44e;
+          }
+          .mermaid-preview:hover .mermaid-copy-btn { opacity: 0.85; }
+          .mermaid-copy-btn:hover { opacity: 1 !important; }
+          .mermaid-copy-btn.is-copied { opacity: 1 !important; }
+          .mermaid-preview.mermaid-error .mermaid-copy-btn,
+          .mermaid-preview:not([data-rendered="true"]) .mermaid-copy-btn,
+          .mermaid-code-block.mermaid-editing + .mermaid-preview .mermaid-copy-btn {
+            display: none;
+          }
+          body.dark-theme .mermaid-copy-btn {
+            border-color: rgba(255,255,255,0.15);
+            background: rgba(255,255,255,0.12);
+            color: rgba(255,255,255,0.9);
+          }
+          body.dark-theme .mermaid-copy-btn.is-copied .icon-check { color: #3fb950; }
+          @media (prefers-reduced-motion: reduce) {
+            .mermaid-copy-btn { transition: none; }
+          }
 
           /* When editing: highlight the preview border, hide hint */
           .mermaid-code-block.mermaid-editing + .mermaid-preview {
@@ -2927,6 +2970,14 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             transition: background 0.15s ease-out;
           }
           .lightbox-btn:hover { background: rgba(255, 255, 255, 0.2); }
+          #lightbox-copy.hidden { display: none; }
+          #lightbox-copy svg { width: 16px; height: 16px; }
+          #lightbox-copy .icon-check { display: none; }
+          #lightbox-copy.is-copied .icon-copy { display: none; }
+          #lightbox-copy.is-copied .icon-check {
+            display: inline-flex;
+            color: #3fb950;
+          }
           #lightbox-zoom-level {
             color: rgba(255, 255, 255, 0.7);
             font-size: 12px;
@@ -3297,6 +3348,10 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             <button id="lightbox-zoom-out" class="lightbox-btn" aria-label="Zoom out">&minus;</button>
             <span id="lightbox-zoom-level">100%</span>
             <button id="lightbox-zoom-in" class="lightbox-btn" aria-label="Zoom in">+</button>
+            <button id="lightbox-copy" class="lightbox-btn lightbox-copy-btn hidden" aria-label="Copy as PNG" title="Copy as PNG">
+              <span class="icon icon-copy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+              <span class="icon icon-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            </button>
             <button id="lightbox-close" class="lightbox-btn" aria-label="Close">&times;</button>
           </div>
         </div>

--- a/src/webview/image-lightbox-plugin.ts
+++ b/src/webview/image-lightbox-plugin.ts
@@ -1,3 +1,9 @@
+import {
+  copyPngBlobToClipboard,
+  reportCopyError,
+  svgToPngBlob,
+} from './svg-to-png';
+
 let scale = 1;
 let translateX = 0;
 let translateY = 0;
@@ -11,6 +17,9 @@ let currentTarget: HTMLElement | null = null;
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 4;
 const SCALE_STEP = 0.25;
+const COPY_FEEDBACK_MS = 1500;
+const PNG_SCALE = 2;
+let copyFeedbackTimer: number | null = null;
 
 function getElements() {
   return {
@@ -23,8 +32,51 @@ function getElements() {
     zoomOut: document.getElementById('lightbox-zoom-out'),
     zoomLevel: document.getElementById('lightbox-zoom-level'),
     close: document.getElementById('lightbox-close'),
+    copy: document.getElementById('lightbox-copy'),
     backdrop: document.querySelector('.lightbox-backdrop'),
   };
+}
+
+function setCopyButtonVisibility(visible: boolean) {
+  const { copy } = getElements();
+  if (!copy) return;
+  copy.classList.toggle('hidden', !visible);
+  copy.classList.remove('is-copied');
+  if (copyFeedbackTimer !== null) {
+    window.clearTimeout(copyFeedbackTimer);
+    copyFeedbackTimer = null;
+  }
+}
+
+async function copyCurrentMermaidToClipboard(button: HTMLButtonElement): Promise<void> {
+  if (button.disabled) return;
+  const { svgWrapper } = getElements();
+  const svgEl = svgWrapper?.querySelector('svg');
+  if (!svgEl) return;
+  // Snapshot at click time: if user edits doc or closes lightbox during the
+  // async work, we still copy the diagram the user clicked on.
+  const svgMarkup = svgEl.outerHTML;
+  button.disabled = true;
+  try {
+    const blob = await svgToPngBlob(svgMarkup, PNG_SCALE);
+    await copyPngBlobToClipboard(blob);
+    if (button.isConnected) {
+      button.classList.add('is-copied');
+      if (copyFeedbackTimer !== null) window.clearTimeout(copyFeedbackTimer);
+      copyFeedbackTimer = window.setTimeout(() => {
+        if (button.isConnected) button.classList.remove('is-copied');
+        copyFeedbackTimer = null;
+      }, COPY_FEEDBACK_MS);
+    }
+  } catch (err) {
+    reportCopyError(
+      `Copy mermaid thất bại: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  } finally {
+    button.disabled = false;
+  }
 }
 
 function applyTransform() {
@@ -72,6 +124,7 @@ function closeLightbox() {
   }
   image?.classList.remove('hidden');
   currentTarget = null;
+  setCopyButtonVisibility(false);
   applyTransform();
 }
 
@@ -99,6 +152,7 @@ export function openLightbox(src: string, alt: string): void {
   image.classList.remove('hidden');
   image.src = src;
   currentTarget = image;
+  setCopyButtonVisibility(false);
 
   setCaption(alt);
   overlay.classList.add('active');
@@ -129,6 +183,7 @@ export function openMermaidLightbox(svgMarkup: string, caption: string): void {
 
   svgWrapper.classList.remove('hidden');
   currentTarget = svgWrapper;
+  setCopyButtonVisibility(true);
 
   setCaption(caption);
   overlay.classList.add('active');
@@ -140,12 +195,18 @@ let initialized = false;
 export function initLightbox(): void {
   if (initialized) return;
   initialized = true;
-  const { close, backdrop, zoomIn, zoomOut, content } = getElements();
+  const { close, backdrop, zoomIn, zoomOut, content, copy } = getElements();
 
   close?.addEventListener('click', closeLightbox);
   backdrop?.addEventListener('click', closeLightbox);
   zoomIn?.addEventListener('click', () => setScale(scale + SCALE_STEP));
   zoomOut?.addEventListener('click', () => setScale(scale - SCALE_STEP));
+  copy?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void copyCurrentMermaidToClipboard(copy as HTMLButtonElement);
+  });
+  setCopyButtonVisibility(false);
 
   document.addEventListener('keydown', (e) => {
     if (!isActive()) return;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -182,6 +182,14 @@ const isMac = /Mac|iPhone|iPod|iPad/.test(navigator.userAgent);
 
 const vscode = acquireVsCodeApi();
 
+document.addEventListener("mermaid-copy-error", (e: Event) => {
+  const detail = (e as CustomEvent<{ message?: string }>).detail;
+  vscode.postMessage({
+    type: "showWarning",
+    message: detail?.message || "Copy mermaid thất bại",
+  });
+});
+
 const lowlight = createLowlight();
 lowlight.register({
   javascript, typescript, python, xml, css, json,

--- a/src/webview/mermaid-plugin.ts
+++ b/src/webview/mermaid-plugin.ts
@@ -16,8 +16,17 @@ import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import mermaid from "mermaid";
 import { openMermaidLightbox } from "./image-lightbox-plugin";
+import {
+    copyPngBlobToClipboard,
+    reportCopyError,
+    svgToPngBlob,
+} from "./svg-to-png";
 
 const EXPAND_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>`;
+const COPY_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+const CHECK_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+const COPY_FEEDBACK_MS = 1500;
+const PNG_SCALE = 2;
 
 const MERMAID_KEY = new PluginKey("mermaidDiagram");
 const RENDER_DEBOUNCE_MS = 500;
@@ -354,6 +363,46 @@ function buildDecorations(doc: any, activeMermaidPos: number): DecorationSet {
                 if (svgEl) openMermaidLightbox(svgEl.outerHTML, "");
             });
             el.appendChild(expandBtn);
+
+            const copyBtn = document.createElement("button");
+            copyBtn.className = "mermaid-copy-btn";
+            copyBtn.type = "button";
+            copyBtn.setAttribute("aria-label", "Copy as PNG");
+            copyBtn.title = "Copy as PNG";
+            copyBtn.innerHTML =
+                `<span class="icon icon-copy">${COPY_ICON_SVG}</span>` +
+                `<span class="icon icon-check">${CHECK_ICON_SVG}</span>`;
+            copyBtn.addEventListener("mousedown", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+            });
+            copyBtn.addEventListener("dblclick", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+            });
+            copyBtn.addEventListener("click", async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (copyBtn.disabled) return;
+                const svgEl = host.querySelector("svg");
+                if (!svgEl) return;
+                const svgMarkup = svgEl.outerHTML;
+                copyBtn.disabled = true;
+                try {
+                    const blob = await svgToPngBlob(svgMarkup, PNG_SCALE);
+                    await copyPngBlobToClipboard(blob);
+                    if (copyBtn.isConnected) flashCopiedState(copyBtn);
+                } catch (err) {
+                    reportCopyError(
+                        `Copy mermaid thất bại: ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    );
+                } finally {
+                    if (copyBtn.isConnected) copyBtn.disabled = false;
+                }
+            });
+            el.appendChild(copyBtn);
             return el;
         }, {
             side: 1, // Place after the node
@@ -410,4 +459,16 @@ function rebuildNodeDecosOnly(
     decos = decos.add(doc, toAdd);
 
     return decos;
+}
+
+function flashCopiedState(button: HTMLElement): void {
+    if (!button.isConnected) return;
+    button.classList.add("is-copied");
+    const host = button as HTMLElement & { __copyTimer?: number };
+    if (host.__copyTimer !== undefined) {
+        window.clearTimeout(host.__copyTimer);
+    }
+    host.__copyTimer = window.setTimeout(() => {
+        if (button.isConnected) button.classList.remove("is-copied");
+    }, COPY_FEEDBACK_MS);
 }

--- a/src/webview/svg-to-png.ts
+++ b/src/webview/svg-to-png.ts
@@ -1,0 +1,124 @@
+/**
+ * Convert an SVG markup string into a PNG Blob at an arbitrary scale,
+ * and write the PNG to the system clipboard. CSP-safe (no eval, no inline
+ * script). Uses a Blob URL + HTMLImageElement + canvas rasterization so the
+ * resulting PNG is crisp at the requested pixel dimensions.
+ */
+
+const LOAD_IMAGE_TIMEOUT_MS = 5000;
+const TO_BLOB_TIMEOUT_MS = 5000;
+
+export async function svgToPngBlob(
+    svgString: string,
+    scale: number = 2,
+): Promise<Blob> {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const svg = doc.documentElement as unknown as SVGSVGElement;
+
+    if (!svg || svg.tagName.toLowerCase() !== "svg") {
+        throw new Error("Invalid SVG markup");
+    }
+
+    const { width, height } = resolveSvgSize(svg);
+    if (width <= 0 || height <= 0) {
+        throw new Error("SVG has zero dimensions");
+    }
+
+    // Ensure explicit width/height so <img> can rasterize; lightbox strips these.
+    svg.setAttribute("width", String(width));
+    svg.setAttribute("height", String(height));
+    if (!svg.getAttribute("xmlns")) {
+        svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    }
+
+    const serialized = new XMLSerializer().serializeToString(svg);
+    // data: URL stays same-origin with the document so the resulting canvas
+    // is not tainted (blob: URLs inside the VS Code webview sandbox can cross
+    // the origin boundary and block canvas.toBlob export).
+    const url = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serialized)}`;
+
+    const img = await loadImage(url);
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(width * scale));
+    canvas.height = Math.max(1, Math.round(height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    return await new Promise<Blob>((resolve, reject) => {
+        const timeoutId = window.setTimeout(
+            () => reject(new Error("canvas.toBlob timed out")),
+            TO_BLOB_TIMEOUT_MS,
+        );
+        canvas.toBlob((b) => {
+            window.clearTimeout(timeoutId);
+            if (b) resolve(b);
+            else reject(new Error("canvas.toBlob returned null"));
+        }, "image/png");
+    });
+}
+
+export async function copyPngBlobToClipboard(blob: Blob): Promise<void> {
+    const w = window as unknown as {
+        ClipboardItem?: typeof ClipboardItem;
+    };
+    if (typeof w.ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+        throw new Error("Clipboard image write API unavailable");
+    }
+    await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blob }),
+    ]);
+}
+
+/**
+ * Emit a CustomEvent that the main webview listener forwards to the extension
+ * as a showWarning message. Keeps this module decoupled from vscode API handle.
+ */
+export function reportCopyError(message: string): void {
+    document.dispatchEvent(
+        new CustomEvent("mermaid-copy-error", { detail: { message } }),
+    );
+}
+
+function resolveSvgSize(svg: SVGSVGElement): {
+    width: number;
+    height: number;
+} {
+    const w = parseFloat(svg.getAttribute("width") || "");
+    const h = parseFloat(svg.getAttribute("height") || "");
+    if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {
+        return { width: w, height: h };
+    }
+    const viewBox = svg.getAttribute("viewBox");
+    if (viewBox) {
+        const parts = viewBox.trim().split(/[\s,]+/).map(parseFloat);
+        if (
+            parts.length === 4 &&
+            Number.isFinite(parts[2]) &&
+            Number.isFinite(parts[3]) &&
+            parts[2] > 0 &&
+            parts[3] > 0
+        ) {
+            return { width: parts[2], height: parts[3] };
+        }
+    }
+    return { width: 0, height: 0 };
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        const timeoutId = window.setTimeout(() => {
+            reject(new Error("Image load timed out"));
+        }, LOAD_IMAGE_TIMEOUT_MS);
+        img.onload = () => {
+            window.clearTimeout(timeoutId);
+            resolve(img);
+        };
+        img.onerror = () => {
+            window.clearTimeout(timeoutId);
+            reject(new Error("Failed to load SVG as image"));
+        };
+        img.src = src;
+    });
+}


### PR DESCRIPTION
## Summary

- Thêm nút copy mermaid diagram sang clipboard ở dạng PNG 2x retina
- 2 vị trí nút: góc trên mermaid preview (cạnh expand) + trong lightbox toolbar
- Render SVG → PNG 2x native qua canvas + data URL (same-origin, không tainted canvas), ghi clipboard bằng `ClipboardItem("image/png")`
- Feedback checkmark 1.5s, VS Code warning dialog khi thất bại
- Bump version 2.8.3 → 2.8.4

## Test plan

- [ ] Mở file `.md` có block mermaid, hover preview, click nút copy → paste vào Preview.app, ảnh PNG nét, kích thước đúng 2x viewbox
- [ ] Click expand mở lightbox, click nút copy trong toolbar → paste giống ảnh preview
- [ ] Mở lightbox ảnh thường (jpg/png) → nút copy tự ẩn
- [ ] Mermaid invalid → preview hiện error → nút copy biến mất
- [ ] Test theme sáng, tối, Catppuccin Mocha → icon màu đúng
- [ ] Ctrl/Cmd+C rapid spam copy button → không gây promise chồng nhau (nút disable trong lúc copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)