### PR TITLE
Release 2.8.6: PDF export rewritten with Puppeteer + unified DOCX pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tui-milkdown-vscode** (496 symbols, 1178 relationships, 41 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tui-milkdown-vscode** (606 symbols, 1351 relationships, 50 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.6] - 2026-04-22
+
+### Added
+
+- **Export to DOCX**: Xuất tài liệu ra Word `.docx` qua `mdast2docx` + plugins (`@m2d/html`, `@m2d/image`, `@m2d/table`, `@m2d/list`). Giữ nguyên heading, list, table, code block, image. Font trong DOCX kế thừa font đang chọn của editor.
+- **Export to PDF**: Xuất tài liệu ra PDF WYSIWYG dùng Chromium headless (`puppeteer-core`). Yêu cầu Chrome/Edge/Chromium/Brave đã cài trên máy; không bundle binary theo extension. Auto-detect path phổ biến, fallback `tuiMarkdown.chromiumPath` hoặc env `PUPPETEER_EXECUTABLE_PATH`.
+- **Setting `tuiMarkdown.chromiumPath`**: Cho phép chỉ định thủ công đường dẫn Chrome/Edge/Chromium/Brave cho PDF export khi auto-detect không bắt đúng binary.
+
+### Changed
+
+- **PDF export viết lại bằng puppeteer-core**: Bỏ `pdfmake` + parser markdown tự viết 339 dòng + bundled Roboto font. Pipeline mới MDAST → HTML (`remark-rehype` + `rehype-highlight` + `rehype-stringify`) → Chromium `page.pdf()`, cho chất lượng WYSIWYG giống preview (syntax highlight code, GitHub table, alert, mermaid base64). Yêu cầu Chrome/Edge/Chromium/Brave đã cài trên máy user, tự dò theo `tuiMarkdown.chromiumPath` → `PUPPETEER_EXECUTABLE_PATH` → system paths quen thuộc. Bundle `out/export-pdf.js` tree-shake puppeteer-core xuống ~2.5MB, VSIX tổng ~5.4MB.
+- **Bỏ bridge MDAST→markdown cho PDF**: Call site giờ truyền thẳng MDAST vào cả `exportToPdf` và `exportToDocx`, loại nguy cơ drift serialize/parse. Hàm `mdastToMarkdown` + dependency `remark-stringify` được xoá.
+- **Mermaid `securityLevel` đổi sang `"loose"`**: Bắt buộc để ELK + `foreignObject` render HTML trong label. Trade-off: SVG sinh ra có thể chứa HTML thô từ markdown, cần treat mermaid từ nguồn không tin cậy như potentially executable. PDF export đã disable JavaScript trong Chromium để chặn leo thang.
+
+### Fixed
+
+- **PDF render relative image**: Image local (`./img.png`) giờ được inline thành base64 trước khi vào Chromium thay vì load từ `about:blank` 404 silent. Pipeline mới walk HAST, đọc file, encode data URL.
+- **Frontmatter handling an toàn**: Bỏ regex strip thủ công, dùng `remark-frontmatter` trong pipeline MDAST để parse frontmatter đúng cú pháp. BOM `﻿` vẫn strip trước khi parse.
+- **Mermaid hash CRLF/LF mismatch**: `hashMermaidCode` normalize line ending `\r\n|\r` → `\n` trước khi trim, đảm bảo file CRLF export mermaid không bị miss.
+- **DOCX fetch remote có timeout**: `AbortController` 30s + check `content-length` / `arrayBuffer.byteLength` không quá 10MB. Ảnh lỗi fetch (timeout, HTTP error, quá lớn) → placeholder 1x1 PNG thay vì abort toàn bộ export.
+- **DOCX ảnh local thiếu**: `fs.readFile` fail không còn làm crash toàn bộ export, thay bằng placeholder + log warning. Ảnh SVG cũng fallback placeholder thay vì throw.
+- **DOCX filename chứa `%` literal**: `decodeURIComponent("50%_off.png")` ném `URIError` không còn crash export; bọc try/catch, fallback raw path.
+- **Export button race duplicate**: Extension track `exportInProgress` flag; request thứ 2 trong khi đang export bị reject với dialog "Đang export, vui lòng đợi". Webview re-enable button qua message `exportDone` thay vì chờ timeout 3s cứng.
+- **Empty document warning**: Export file trống / chỉ có frontmatter hiện cảnh báo "Document trống, không có nội dung để export" thay vì sinh file rỗng silent.
+- **PDF font-family CSS context**: Font user chọn giờ được sanitize qua whitelist `[A-Za-z0-9 _-]` thay vì `escapeHtml` (CSS `<style>` không decode HTML entities, trước đây font có dấu `"` làm declaration invalid).
+- **PDF Chromium sandbox conditional**: `--no-sandbox` chỉ pass khi Linux + root; macOS/Windows/Linux user thường giữ nguyên isolation mặc định.
+- **PDF strip HTML nguy hiểm**: Bỏ `<script>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<base>`, `<meta http-equiv>` trước khi vào Chromium (bổ sung thêm cho `setJavaScriptEnabled(false)`).
+- **PDF `waitUntil: "networkidle0"`**: Đổi từ `"load"` sang `"networkidle0"` để đợi ảnh load hết trước khi `page.pdf()` chạy.
+- **PDF `rehype-highlight` `detect: false`**: Chỉ syntax highlight khi code block có language. Giảm CPU trên document lớn.
+- **Open Folder sau export**: Dùng `vscode.commands.executeCommand("revealFileInOS", ...)` thay `openExternal(folder)` để reveal đúng file trong Finder/Explorer cross-platform.
+- **Chromium discovery chắc chắn hơn**: Check `fs.constants.X_OK` ngoài `isFile()` để loại path không executable; strip quote thừa quanh `chromiumPath` nếu user paste nguyên vẹn `"C:\...\chrome.exe"`.
+- **Chromium cache invalidate khi đổi setting**: `onDidChangeConfiguration` listen `tuiMarkdown.chromiumPath` → gọi `clearChromiumCache()`, không cần reload window.
+- **Puppeteer launch error message thân thiện**: Wrap lỗi launch thành "Không khởi chạy được Chromium tại `<path>`: <original>. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath".
+- **SVG zero-dimension fallback**: `svgToPngBlob` dùng fallback 800×600 + console.warn khi SVG không có width/height/viewBox, thay vì throw silent.
+
 ## [2.8.5] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to "TUI Markdown Editor" extension.
 - **Chromium cache invalidate khi đổi setting**: `onDidChangeConfiguration` listen `tuiMarkdown.chromiumPath` → gọi `clearChromiumCache()`, không cần reload window.
 - **Puppeteer launch error message thân thiện**: Wrap lỗi launch thành "Không khởi chạy được Chromium tại `<path>`: <original>. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath".
 - **SVG zero-dimension fallback**: `svgToPngBlob` dùng fallback 800×600 + console.warn khi SVG không có width/height/viewBox, thay vì throw silent.
+- **Git Graph diff bị chặn ([#48](https://github.com/hoangvantuan/tui-milkdown-vscode/issues/48))**: Thêm scheme `git-graph` vào `configurationDefaults.workbench.editorAssociations` để Tui Milkdown không chặn mở file markdown khi xem diff từ Git Graph plugin. Trước đó chỉ exclude `git` và `gitlens`.
 
 ## [2.8.5] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,49 +6,49 @@ All notable changes to "TUI Markdown Editor" extension.
 
 ### Added
 
-- **Export to DOCX**: Xuất tài liệu ra Word `.docx` qua `mdast2docx` + plugins (`@m2d/html`, `@m2d/image`, `@m2d/table`, `@m2d/list`). Giữ nguyên heading, list, table, code block, image. Font trong DOCX kế thừa font đang chọn của editor.
-- **Export to PDF**: Xuất tài liệu ra PDF WYSIWYG dùng Chromium headless (`puppeteer-core`). Yêu cầu Chrome/Edge/Chromium/Brave đã cài trên máy; không bundle binary theo extension. Auto-detect path phổ biến, fallback `tuiMarkdown.chromiumPath` hoặc env `PUPPETEER_EXECUTABLE_PATH`.
-- **Setting `tuiMarkdown.chromiumPath`**: Cho phép chỉ định thủ công đường dẫn Chrome/Edge/Chromium/Brave cho PDF export khi auto-detect không bắt đúng binary.
+- **Export to DOCX**: Export documents to Word `.docx` via `mdast2docx` + plugins (`@m2d/html`, `@m2d/image`, `@m2d/table`, `@m2d/list`). Preserves headings, lists, tables, code blocks, and images. DOCX font inherits the editor's currently selected font.
+- **Export to PDF**: Export documents to WYSIWYG PDF using headless Chromium (`puppeteer-core`). Requires Chrome/Edge/Chromium/Brave installed on the system; no binary bundled with the extension. Auto-detects common paths, falls back to `tuiMarkdown.chromiumPath` or env `PUPPETEER_EXECUTABLE_PATH`.
+- **Setting `tuiMarkdown.chromiumPath`**: Allows manually specifying the Chrome/Edge/Chromium/Brave path for PDF export when auto-detection does not find the correct binary.
 
 ### Changed
 
-- **PDF export viết lại bằng puppeteer-core**: Bỏ `pdfmake` + parser markdown tự viết 339 dòng + bundled Roboto font. Pipeline mới MDAST → HTML (`remark-rehype` + `rehype-highlight` + `rehype-stringify`) → Chromium `page.pdf()`, cho chất lượng WYSIWYG giống preview (syntax highlight code, GitHub table, alert, mermaid base64). Yêu cầu Chrome/Edge/Chromium/Brave đã cài trên máy user, tự dò theo `tuiMarkdown.chromiumPath` → `PUPPETEER_EXECUTABLE_PATH` → system paths quen thuộc. Bundle `out/export-pdf.js` tree-shake puppeteer-core xuống ~2.5MB, VSIX tổng ~5.4MB.
-- **Bỏ bridge MDAST→markdown cho PDF**: Call site giờ truyền thẳng MDAST vào cả `exportToPdf` và `exportToDocx`, loại nguy cơ drift serialize/parse. Hàm `mdastToMarkdown` + dependency `remark-stringify` được xoá.
-- **Mermaid `securityLevel` đổi sang `"loose"`**: Bắt buộc để ELK + `foreignObject` render HTML trong label. Trade-off: SVG sinh ra có thể chứa HTML thô từ markdown, cần treat mermaid từ nguồn không tin cậy như potentially executable. PDF export đã disable JavaScript trong Chromium để chặn leo thang.
+- **PDF export rewritten with puppeteer-core**: Removed `pdfmake` + custom 339-line markdown parser + bundled Roboto font. New pipeline: MDAST → HTML (`remark-rehype` + `rehype-highlight` + `rehype-stringify`) → Chromium `page.pdf()`, delivering WYSIWYG quality matching the preview (syntax-highlighted code, GitHub tables, alerts, mermaid base64). Requires Chrome/Edge/Chromium/Brave installed on the user's machine, auto-detected via `tuiMarkdown.chromiumPath` → `PUPPETEER_EXECUTABLE_PATH` → well-known system paths. Bundle `out/export-pdf.js` tree-shakes puppeteer-core to ~2.5MB, total VSIX ~5.4MB.
+- **Removed MDAST→markdown bridge for PDF**: Call sites now pass MDAST directly to both `exportToPdf` and `exportToDocx`, eliminating serialize/parse drift risk. `mdastToMarkdown` function + `remark-stringify` dependency removed.
+- **Mermaid `securityLevel` changed to `"loose"`**: Required for ELK + `foreignObject` to render HTML inside labels. Trade-off: generated SVG may contain raw HTML from markdown; treat mermaid from untrusted sources as potentially executable. PDF export disables JavaScript in Chromium to prevent escalation.
 
 ### Fixed
 
-- **PDF render relative image**: Image local (`./img.png`) giờ được inline thành base64 trước khi vào Chromium thay vì load từ `about:blank` 404 silent. Pipeline mới walk HAST, đọc file, encode data URL.
-- **Frontmatter handling an toàn**: Bỏ regex strip thủ công, dùng `remark-frontmatter` trong pipeline MDAST để parse frontmatter đúng cú pháp. BOM `﻿` vẫn strip trước khi parse.
-- **Mermaid hash CRLF/LF mismatch**: `hashMermaidCode` normalize line ending `\r\n|\r` → `\n` trước khi trim, đảm bảo file CRLF export mermaid không bị miss.
-- **DOCX fetch remote có timeout**: `AbortController` 30s + check `content-length` / `arrayBuffer.byteLength` không quá 10MB. Ảnh lỗi fetch (timeout, HTTP error, quá lớn) → placeholder 1x1 PNG thay vì abort toàn bộ export.
-- **DOCX ảnh local thiếu**: `fs.readFile` fail không còn làm crash toàn bộ export, thay bằng placeholder + log warning. Ảnh SVG cũng fallback placeholder thay vì throw.
-- **DOCX filename chứa `%` literal**: `decodeURIComponent("50%_off.png")` ném `URIError` không còn crash export; bọc try/catch, fallback raw path.
-- **Export button race duplicate**: Extension track `exportInProgress` flag; request thứ 2 trong khi đang export bị reject với dialog "Đang export, vui lòng đợi". Webview re-enable button qua message `exportDone` thay vì chờ timeout 3s cứng.
-- **Empty document warning**: Export file trống / chỉ có frontmatter hiện cảnh báo "Document trống, không có nội dung để export" thay vì sinh file rỗng silent.
-- **PDF font-family CSS context**: Font user chọn giờ được sanitize qua whitelist `[A-Za-z0-9 _-]` thay vì `escapeHtml` (CSS `<style>` không decode HTML entities, trước đây font có dấu `"` làm declaration invalid).
-- **PDF Chromium sandbox conditional**: `--no-sandbox` chỉ pass khi Linux + root; macOS/Windows/Linux user thường giữ nguyên isolation mặc định.
-- **PDF strip HTML nguy hiểm**: Bỏ `<script>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<base>`, `<meta http-equiv>` trước khi vào Chromium (bổ sung thêm cho `setJavaScriptEnabled(false)`).
-- **PDF `waitUntil: "networkidle0"`**: Đổi từ `"load"` sang `"networkidle0"` để đợi ảnh load hết trước khi `page.pdf()` chạy.
-- **PDF `rehype-highlight` `detect: false`**: Chỉ syntax highlight khi code block có language. Giảm CPU trên document lớn.
-- **Open Folder sau export**: Dùng `vscode.commands.executeCommand("revealFileInOS", ...)` thay `openExternal(folder)` để reveal đúng file trong Finder/Explorer cross-platform.
-- **Chromium discovery chắc chắn hơn**: Check `fs.constants.X_OK` ngoài `isFile()` để loại path không executable; strip quote thừa quanh `chromiumPath` nếu user paste nguyên vẹn `"C:\...\chrome.exe"`.
-- **Chromium cache invalidate khi đổi setting**: `onDidChangeConfiguration` listen `tuiMarkdown.chromiumPath` → gọi `clearChromiumCache()`, không cần reload window.
-- **Puppeteer launch error message thân thiện**: Wrap lỗi launch thành "Không khởi chạy được Chromium tại `<path>`: <original>. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath".
-- **SVG zero-dimension fallback**: `svgToPngBlob` dùng fallback 800×600 + console.warn khi SVG không có width/height/viewBox, thay vì throw silent.
-- **Git Graph diff bị chặn ([#48](https://github.com/hoangvantuan/tui-milkdown-vscode/issues/48))**: Thêm scheme `git-graph` vào `configurationDefaults.workbench.editorAssociations` để Tui Milkdown không chặn mở file markdown khi xem diff từ Git Graph plugin. Trước đó chỉ exclude `git` và `gitlens`.
+- **PDF render relative image**: Local images (`./img.png`) are now inlined as base64 before entering Chromium instead of loading from `about:blank` (which silently 404s). New pipeline walks HAST, reads files, encodes data URLs.
+- **Safe frontmatter handling**: Removed manual regex stripping, using `remark-frontmatter` in the MDAST pipeline for proper frontmatter parsing. BOM `﻿` is still stripped before parsing.
+- **Mermaid hash CRLF/LF mismatch**: `hashMermaidCode` normalizes line endings `\r\n|\r` → `\n` before trimming, ensuring CRLF files do not miss mermaid export.
+- **DOCX remote fetch timeout**: `AbortController` 30s + `content-length` / `arrayBuffer.byteLength` check capped at 10MB. Failed fetches (timeout, HTTP error, oversized) → placeholder 1x1 PNG instead of aborting the entire export.
+- **DOCX missing local image**: `fs.readFile` failure no longer crashes the entire export; replaced with placeholder + log warning. SVG images also fall back to placeholder instead of throwing.
+- **DOCX filename with literal `%`**: `decodeURIComponent("50%_off.png")` throwing `URIError` no longer crashes export; wrapped with try/catch, falls back to raw path.
+- **Export button race duplicate**: Extension tracks `exportInProgress` flag; a second request while exporting is rejected with dialog "Export in progress, please wait". Webview re-enables button via `exportDone` message instead of relying on a fixed 3s timeout.
+- **Empty document warning**: Exporting an empty file or one with only frontmatter shows warning "Document is empty, nothing to export" instead of silently generating an empty file.
+- **PDF font-family CSS context**: User-selected font is now sanitized via whitelist `[A-Za-z0-9 _-]` instead of `escapeHtml` (CSS `<style>` does not decode HTML entities; previously fonts with `"` made the declaration invalid).
+- **PDF Chromium sandbox conditional**: `--no-sandbox` only passed on Linux + root; macOS/Windows/Linux users keep default Chromium isolation.
+- **PDF strip dangerous HTML**: Removes `<script>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<base>`, `<meta http-equiv>` before feeding to Chromium (supplements `setJavaScriptEnabled(false)`).
+- **PDF `waitUntil: "networkidle0"`**: Changed from `"load"` to `"networkidle0"` to wait for all images to load before `page.pdf()` runs.
+- **PDF `rehype-highlight` `detect: false`**: Only syntax-highlights code blocks with a language specified. Reduces CPU on large documents.
+- **Open Folder after export**: Uses `vscode.commands.executeCommand("revealFileInOS", ...)` instead of `openExternal(folder)` to reveal the correct file in Finder/Explorer cross-platform.
+- **More robust Chromium discovery**: Checks `fs.constants.X_OK` in addition to `isFile()` to filter non-executable paths; strips extra quotes around `chromiumPath` if user pastes `"C:\...\chrome.exe"` verbatim.
+- **Chromium cache invalidation on setting change**: `onDidChangeConfiguration` listens for `tuiMarkdown.chromiumPath` → calls `clearChromiumCache()`, no window reload needed.
+- **Friendly Puppeteer launch error message**: Wraps launch error as "Failed to launch Chromium at `<path>`: <original>. Check execute permission or configure tuiMarkdown.chromiumPath."
+- **SVG zero-dimension fallback**: `svgToPngBlob` uses 800×600 fallback + console.warn when SVG has no width/height/viewBox, instead of throwing silently.
+- **Git Graph diff blocked ([#48](https://github.com/hoangvantuan/tui-milkdown-vscode/issues/48))**: Added `git-graph` scheme to `configurationDefaults.workbench.editorAssociations` so TUI Markdown does not block opening markdown files when viewing diffs from Git Graph plugin. Previously only `git` and `gitlens` were excluded.
 
 ## [2.8.5] - 2026-04-22
 
 ### Added
 
-- **Copy Mermaid as PNG**: Nút "copy" xuất hiện trên mermaid preview khi hover (cạnh nút expand) và trong lightbox toolbar. Click sẽ render SVG sang PNG bitmap (scale 2x cho retina) rồi ghi vào clipboard bằng `navigator.clipboard.write` + `ClipboardItem("image/png")`. Dán được trực tiếp vào Slack, Word, Figma, Notion, Preview.app. Feedback checkmark 1.5s khi thành công, VS Code warning dialog khi lỗi. Nút tự ẩn trên `.mermaid-error`, mode editing, và lightbox mode ảnh thường.
+- **Copy Mermaid as PNG**: "Copy" button appears on mermaid preview hover (next to expand button) and in the lightbox toolbar. Click renders SVG to PNG bitmap (2x scale for retina) and writes to clipboard via `navigator.clipboard.write` + `ClipboardItem("image/png")`. Can be pasted directly into Slack, Word, Figma, Notion, Preview.app. Checkmark feedback for 1.5s on success, VS Code warning dialog on error. Button auto-hides on `.mermaid-error`, editing mode, and regular image lightbox mode.
 
 ## [2.8.4] - 2026-04-18
 
 ### Fixed
 
-- **Loại file thừa trong package**: Cập nhật `.vscodeignore` để loại bỏ file dev (`.agent`, `.github`, `.mcp.json`, `_bmad`, `AGENTS.md`, `.gitnexus`, `skills-lock.json`, `.DS_Store`) khỏi extension package. Giảm kích thước package và dọn sạch nội dung không cần thiết.
+- **Remove extraneous files from package**: Updated `.vscodeignore` to exclude dev files (`.agent`, `.github`, `.mcp.json`, `_bmad`, `AGENTS.md`, `.gitnexus`, `skills-lock.json`, `.DS_Store`) from the extension package. Reduces package size and removes unnecessary content.
 
 ## [2.8.3] - 2026-04-18
 
@@ -68,7 +68,7 @@ All notable changes to "TUI Markdown Editor" extension.
 
 ### Fixed
 
-- **Mermaid SVG Clipping**: Cho phép `foreignObject` label trong mermaid diagram render vượt khỏi bbox (áp dụng `overflow: visible` cho SVG và mọi phần tử con bên trong `.mermaid-svg-host`), khắc phục tình trạng nhãn bị cắt ở mép diagram.
+- **Mermaid SVG Clipping**: Allow `foreignObject` labels in mermaid diagrams to render beyond the bounding box (apply `overflow: visible` to SVG and all child elements inside `.mermaid-svg-host`), fixing labels being clipped at diagram edges.
 
 ## [2.8.1] - 2026-04-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -717,27 +717,27 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 ## Mermaid Copy as PNG
 
 **Module** (`src/webview/svg-to-png.ts`):
-* `svgToPngBlob(svgString, scale = 2)`: DOMParser → ensure `width`/`height` (fallback to `viewBox`) → Blob SVG → `URL.createObjectURL` → `<Image>` → `canvas.drawImage` at `native * scale` → `canvas.toBlob('image/png')`. Scale qua canvas (không qua CSS) đảm bảo PNG nét mọi dpi.
-* `copyPngBlobToClipboard(blob)`: `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])`. Throws nếu `ClipboardItem` hoặc `clipboard.write` unavailable.
-* `reportCopyError(message)`: Dispatch `CustomEvent('mermaid-copy-error', { detail: { message } })` trên `document`. Module giữ decoupled với vscode API handle.
+* `svgToPngBlob(svgString, scale = 2)`: DOMParser → ensure `width`/`height` (fallback to `viewBox`) → Blob SVG → `URL.createObjectURL` → `<Image>` → `canvas.drawImage` at `native * scale` → `canvas.toBlob('image/png')`. Scales via canvas (not CSS) to ensure crisp PNG at all DPIs.
+* `copyPngBlobToClipboard(blob)`: `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])`. Throws if `ClipboardItem` or `clipboard.write` is unavailable.
+* `reportCopyError(message)`: Dispatches `CustomEvent('mermaid-copy-error', { detail: { message } })` on `document`. Keeps the module decoupled from the vscode API handle.
 
 **Preview button** (`src/webview/mermaid-plugin.ts`):
-* `.mermaid-copy-btn` injected cạnh `.mermaid-expand-btn` trong widget decoration (cùng vòng tạo button). Click: query `svg` trong `.mermaid-svg-host` → `svgToPngBlob` → `copyPngBlobToClipboard` → `flashCopiedState()` (thêm `.is-copied` 1.5s, 2 `<svg>` icon copy/check toggle qua CSS).
-* Tự ẩn qua CSS khi `.mermaid-error`, `.mermaid-editing`, hoặc chưa `data-rendered="true"`.
+* `.mermaid-copy-btn` injected next to `.mermaid-expand-btn` in the widget decoration (same button creation loop). Click: queries `svg` in `.mermaid-svg-host` → `svgToPngBlob` → `copyPngBlobToClipboard` → `flashCopiedState()` (adds `.is-copied` for 1.5s, two `<svg>` icons copy/check toggled via CSS).
+* Auto-hidden via CSS when `.mermaid-error`, `.mermaid-editing`, or `data-rendered="true"` is not set.
 
 **Lightbox button** (`src/webview/image-lightbox-plugin.ts`):
-* `#lightbox-copy` trong `.lightbox-controls` (trước nút close). Wired trong `initLightbox`, toggle hiển thị qua `setCopyButtonVisibility()`:
+* `#lightbox-copy` in `.lightbox-controls` (before the close button). Wired in `initLightbox`, visibility toggled via `setCopyButtonVisibility()`:
   * `openMermaidLightbox` → visible
-  * `openLightbox` (image) và `closeLightbox` → hidden
-* Click đọc SVG từ `#lightbox-svg.querySelector('svg')` → cùng flow với preview.
+  * `openLightbox` (image) and `closeLightbox` → hidden
+* Click reads SVG from `#lightbox-svg.querySelector('svg')` → same flow as preview.
 
 **Error forwarding** (`src/webview/main.ts`):
-* Listener `document.addEventListener('mermaid-copy-error', ...)` forward `detail.message` tới extension bằng `vscode.postMessage({ type: 'showWarning', message })`. Giữ `svg-to-png.ts` không cần `acquireVsCodeApi()` reference.
+* Listener `document.addEventListener('mermaid-copy-error', ...)` forwards `detail.message` to the extension via `vscode.postMessage({ type: 'showWarning', message })`. Keeps `svg-to-png.ts` from needing an `acquireVsCodeApi()` reference.
 
 **Gotchas**:
-* Lightbox strips `width`/`height` attribute của SVG (để zoom tự do), nhưng `svgToPngBlob` đã normalize qua `resolveSvgSize()` (đọc `viewBox` khi thiếu attr) rồi set lại trước khi serialize.
-* Clipboard requires secure context — VS Code webview đủ điều kiện. Nếu runtime cũ thiếu `ClipboardItem`, button ném lỗi, error được gửi thành VS Code warning dialog.
-* `XMLSerializer` + Blob SVG tránh inline `<script>` → CSP-safe, không cần tweak CSP.
+* Lightbox strips `width`/`height` attributes from SVG (for free zoom), but `svgToPngBlob` already normalizes via `resolveSvgSize()` (reads `viewBox` when attributes are missing) then sets them back before serializing.
+* Clipboard requires secure context — VS Code webview qualifies. If an older runtime lacks `ClipboardItem`, the button throws an error, which is forwarded as a VS Code warning dialog.
+* `XMLSerializer` + Blob SVG avoids inline `<script>` → CSP-safe, no CSP tweaking needed.
 
 ## GitHub-Style Alerts
 
@@ -809,9 +809,9 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 **Provider hook** (`src/markdownEditorProvider.ts` case `"export"`):
 
-* Enforces a single-in-flight export per webview via the `exportInProgress` flag. A second click while busy gets rejected with "Đang export, vui lòng đợi" + `exportDone {success: false, reason: "busy"}` back to the webview.
+* Enforces a single-in-flight export per webview via the `exportInProgress` flag. A second click while busy gets rejected with "Export in progress, please wait for the current export to finish." + `exportDone {success: false, reason: "busy"}` back to the webview.
 * On success or error, extension sends `exportDone` so the webview can re-enable its button without relying on a 3 s timeout. The webview also keeps a 60 s safety timer in case the message is lost.
-* After build the MDAST, provider warns "Document trống, không có nội dung để export" when `mdast.children` is empty (or was only frontmatter).
+* After building the MDAST, provider warns "Document is empty, nothing to export." when `mdast.children` is empty (or was only frontmatter).
 
 **DOCX** (`src/utils/export-docx.ts`):
 
@@ -830,7 +830,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 * HTML is wrapped in a GitHub-like document template (`buildHtmlDocument`). Font family user chose is passed through `cssFontFamilyToken()` — NOT `escapeHtml`. CSS `<style>` text does not decode HTML entities, so a whitelist strip (`[A-Za-z0-9 _-]`) is used to keep the `font-family` declaration valid.
 * Chromium launch: `puppeteer.launch({ args: puppeteerLaunchArgs() })`. `puppeteerLaunchArgs()` returns `["--no-sandbox", "--disable-setuid-sandbox"]` ONLY on Linux-as-root — macOS/Windows/Linux-as-user keep Chromium's default sandbox.
 * `page.setJavaScriptEnabled(false)` before `setContent`. `waitUntil: "networkidle0"` so inlined images finish decoding before `page.pdf()` prints.
-* Launch errors are wrapped: "Không khởi chạy được Chromium tại `<path>`: <original>. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath."
+* Launch errors are wrapped: "Failed to launch Chromium at `<path>`: <original>. Check execute permission or configure tuiMarkdown.chromiumPath."
 * Extension does NOT ship a Chromium binary. `chromium-discovery.ts` looks up an installed Chrome/Edge/Chromium/Brave via (in order): `tuiMarkdown.chromiumPath` setting → `PUPPETEER_EXECUTABLE_PATH` env → OS-specific well-known paths. First hit is cached for the session.
 * Path validation uses `fs.accessSync(path, X_OK)` on top of `isFile()`. Leading/trailing quotes in the setting value are stripped so `"C:\...\chrome.exe"` works.
 * The provider listens for `tuiMarkdown.chromiumPath` changes via `onDidChangeConfiguration` and calls `clearChromiumCache()` — no reload needed. (`clearChromiumCache` is re-exported from `export-pdf.js` so the provider can reach it without a separate bundle entry for `chromium-discovery`.)
@@ -839,7 +839,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 **Gotchas**:
 
 * **VS Code Electron is not a Chromium puppeteer can drive.** `process.execPath` in the extension host points at an Electron helper — launching puppeteer against it fails. This is why the discovery module explicitly does not try `process.execPath`.
-* **Chromium is required on the user's machine.** PDF export surfaces a "Mở Settings" error dialog when no binary is found. Fallback was intentionally NOT implemented to keep the bundle small and the pipeline WYSIWYG.
+* **Chromium is required on the user's machine.** PDF export surfaces an "Open Settings" error dialog when no binary is found. Fallback was intentionally NOT implemented to keep the bundle small and the pipeline WYSIWYG.
 * **Do NOT add `--disable-web-security` or re-enable JS** on the puppeteer page. `--no-sandbox` is also gated to Linux root only — do not widen.
 * **Do NOT drop `stripDangerousHtmlTags` or `inlineRelativeImages`.** They are the reason user markdown with `<iframe src="file:///...">` or `![](./img.png)` behaves safely and correctly.
 * `findChromiumExecutable()` result is cached per session — clear with `clearChromiumCache()` if a test needs to re-probe. The provider auto-clears on `tuiMarkdown.chromiumPath` changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@ src/
 ├── utils/
 │   ├── getNonce.ts           # CSP nonce generator
 │   ├── clean-image-path.ts   # Shared image path cleaning utility (removes titles, angle brackets)
-│   └── image-rename-handler.ts # Image rename/delete detection, execution, workspace reference updates
+│   ├── image-rename-handler.ts # Image rename/delete detection, execution, workspace reference updates
+│   ├── markdown-ast.ts       # Shared MDAST pipeline (parse + mermaid image substitution)
+│   ├── export-docx.ts        # MDAST → DOCX via mdast2docx (lazy-loaded bundle)
+│   ├── export-pdf.ts         # MDAST → HTML → Chromium page.pdf (lazy-loaded bundle)
+│   └── chromium-discovery.ts # Locate Chrome/Edge/Chromium/Brave executable for PDF export
 └── webview/
     ├── main.ts               # Browser-side Tiptap editor
     ├── index.html            # HTML template for webview (loaded by markdownEditorProvider)
@@ -370,7 +374,7 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
   * `openMermaidLightbox(svgMarkup, caption)` — SVG outer HTML → `#lightbox-svg` wrapper
   * `initLightbox()` called once in `init()`
 * Mousedown listener attached to `.lightbox-content` so both targets share drag-pan logic
-* Mermaid SVG is sanitized by `mermaid.render()` with `securityLevel: "strict"`, so `innerHTML` assignment is safe for this specific input
+* Mermaid SVG is rendered with `securityLevel: "loose"` (required for ELK + `foreignObject` HTML labels). `innerHTML` assignment into the lightbox trusts this input. See the "Mermaid Diagrams" section below for the security trade-off note.
 * Mermaid expand button is injected in `mermaid-plugin.ts` widget decoration (top-left of `.mermaid-preview`, hidden on `.mermaid-error` or while editing); click reads `svgEl.outerHTML` from `.mermaid-svg-host` and calls `openMermaidLightbox`
 
 ## Content Zoom
@@ -708,6 +712,8 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 **Dependencies**: `mermaid@^11.12.2`
 
+**Security note — `securityLevel: "loose"`**: Mermaid is initialized with `securityLevel: "loose"` in both `ensureMermaidInit()` and `updateMermaidTheme()` (decision D1 in `_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md`). "loose" is required so ELK can render `foreignObject` HTML inside labels — "strict" strips HTML and the layout looks flat. Trade-off: a mermaid label can contain inline HTML such as `<img onerror=...>`, which is passed through to the rendered SVG. That SVG is then written to the DOM via `innerHTML` in both the preview host and the lightbox wrapper. **Implication**: treat third-party mermaid source (pasted from untrusted markdown) as potentially executable. The PDF exporter disables JavaScript in the Chromium page so this does not escalate there; the webview itself relies on VS Code's webview sandbox. Do NOT relax the sandbox or enable `--allow-scripts` for mermaid rendering.
+
 ## Mermaid Copy as PNG
 
 **Module** (`src/webview/svg-to-png.ts`):
@@ -791,6 +797,55 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 
 * Groups consecutive same-type segments into single list block
 
+## Export (DOCX / PDF)
+
+**Shared pipeline** (`src/utils/markdown-ast.ts`):
+
+* Extension host parses the raw document (only the BOM stripped, frontmatter handled by `remark-frontmatter`) into a single MDAST once per export via `parseMarkdownToMdast()`.
+* The provider pops the leading `yaml`/`toml` node so frontmatter is not rendered as content.
+* Mermaid code blocks are swapped for `image` nodes via `replaceMermaidBlocks()`. Correlation key: `hashMermaidCode()` — djb2 with `\r\n|\r → \n` normalization + trim, so CRLF files match the LF-normalized code the webview has in `data-mermaid-src`.
+* Both exporters consume the same MDAST — no regex replace drift between webview text and export text.
+* Webview pre-renders mermaid to PNG via `svg-to-png.ts` (DOMParser + native `canvas.toBlob`), sends `{ code, base64 }[]` in the `export` message. `svg-to-png.ts` falls back to 800×600 with `console.warn` when the SVG has no width/height/viewBox.
+
+**Provider hook** (`src/markdownEditorProvider.ts` case `"export"`):
+
+* Enforces a single-in-flight export per webview via the `exportInProgress` flag. A second click while busy gets rejected with "Đang export, vui lòng đợi" + `exportDone {success: false, reason: "busy"}` back to the webview.
+* On success or error, extension sends `exportDone` so the webview can re-enable its button without relying on a 3 s timeout. The webview also keeps a 60 s safety timer in case the message is lost.
+* After build the MDAST, provider warns "Document trống, không có nội dung để export" when `mdast.children` is empty (or was only frontmatter).
+
+**DOCX** (`src/utils/export-docx.ts`):
+
+* `mdast2docx` core + `@m2d/html`, `@m2d/image`, `@m2d/table`, `@m2d/list` plugins.
+* Node-side `imageResolver` handles data URLs, `http(s)` fetch, and relative file paths against the document directory. Failure modes are non-fatal — the resolver returns a 1×1 transparent PNG placeholder so one broken image does not kill a 50-image export. Warnings log to the console.
+* Remote fetch uses `AbortController` with a 30 s timeout and rejects when `content-length` OR the downloaded `arrayBuffer` exceeds 10 MB.
+* SVG images (not the mermaid data-URL kind) cannot be embedded in DOCX — resolver returns the placeholder + warns instead of throwing.
+* `decodeURIComponent` is wrapped in `safeDecodeURIComponent` to survive filenames with literal `%` (e.g. `50%_off.png`).
+* `fontFamily` option is applied via `docxProps.styles.default.document.run.font` so DOCX inherits the editor's active font.
+
+**PDF** (`src/utils/export-pdf.ts`):
+
+* MDAST → HAST via `remark-rehype` (`allowDangerousHtml: true`) + `rehype-highlight` (`detect: false, ignoreMissing: true`).
+* Before stringify, `inlineRelativeImages(hast, baseDir)` walks the tree, reads any `<img>` with a relative/local path from disk, and rewrites `src` to a `data:` URL. Without this, Chromium's `about:blank` page would 404 all relative image references.
+* `rehype-stringify` then produces HTML, which is passed through `stripDangerousHtmlTags()` to remove `<script>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<base>`, and `<meta http-equiv>` tags. This is a narrow defence-in-depth strip, not a full sanitizer — it pairs with JS-disabled Chromium.
+* HTML is wrapped in a GitHub-like document template (`buildHtmlDocument`). Font family user chose is passed through `cssFontFamilyToken()` — NOT `escapeHtml`. CSS `<style>` text does not decode HTML entities, so a whitelist strip (`[A-Za-z0-9 _-]`) is used to keep the `font-family` declaration valid.
+* Chromium launch: `puppeteer.launch({ args: puppeteerLaunchArgs() })`. `puppeteerLaunchArgs()` returns `["--no-sandbox", "--disable-setuid-sandbox"]` ONLY on Linux-as-root — macOS/Windows/Linux-as-user keep Chromium's default sandbox.
+* `page.setJavaScriptEnabled(false)` before `setContent`. `waitUntil: "networkidle0"` so inlined images finish decoding before `page.pdf()` prints.
+* Launch errors are wrapped: "Không khởi chạy được Chromium tại `<path>`: <original>. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath."
+* Extension does NOT ship a Chromium binary. `chromium-discovery.ts` looks up an installed Chrome/Edge/Chromium/Brave via (in order): `tuiMarkdown.chromiumPath` setting → `PUPPETEER_EXECUTABLE_PATH` env → OS-specific well-known paths. First hit is cached for the session.
+* Path validation uses `fs.accessSync(path, X_OK)` on top of `isFile()`. Leading/trailing quotes in the setting value are stripped so `"C:\...\chrome.exe"` works.
+* The provider listens for `tuiMarkdown.chromiumPath` changes via `onDidChangeConfiguration` and calls `clearChromiumCache()` — no reload needed. (`clearChromiumCache` is re-exported from `export-pdf.js` so the provider can reach it without a separate bundle entry for `chromium-discovery`.)
+* Bundling: `puppeteer-core` is bundled INTO `out/export-pdf.js` via esbuild tree-shake (~2.5MB minified) — NOT external. `.vscodeignore` excludes `node_modules/**`, so external wouldn't ship.
+
+**Gotchas**:
+
+* **VS Code Electron is not a Chromium puppeteer can drive.** `process.execPath` in the extension host points at an Electron helper — launching puppeteer against it fails. This is why the discovery module explicitly does not try `process.execPath`.
+* **Chromium is required on the user's machine.** PDF export surfaces a "Mở Settings" error dialog when no binary is found. Fallback was intentionally NOT implemented to keep the bundle small and the pipeline WYSIWYG.
+* **Do NOT add `--disable-web-security` or re-enable JS** on the puppeteer page. `--no-sandbox` is also gated to Linux root only — do not widen.
+* **Do NOT drop `stripDangerousHtmlTags` or `inlineRelativeImages`.** They are the reason user markdown with `<iframe src="file:///...">` or `![](./img.png)` behaves safely and correctly.
+* `findChromiumExecutable()` result is cached per session — clear with `clearChromiumCache()` if a test needs to re-probe. The provider auto-clears on `tuiMarkdown.chromiumPath` changes.
+* Mermaid rendering is done client-side (webview) and shipped to the extension as base64 data URLs, so the exporters don't need mermaid / graphviz installed on the host.
+* Hash stability: webview's `data-mermaid-src` holds ProseMirror's `node.textContent` (already LF-normalized), extension hashes remark-parse's `node.value` — both go through `hashMermaidCode` which re-normalizes line endings, so CRLF files and indented fences still match.
+
 ## Development Guidelines
 
 **Tiptap-First Approach:**
@@ -860,7 +915,7 @@ After every development cycle (new feature, bug fix, refactor), update these fil
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tui-milkdown-vscode** (496 symbols, 1178 relationships, 41 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tui-milkdown-vscode** (606 symbols, 1351 relationships, 50 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 - **Reading Progress Bar**: Fixed top bar tracking scroll position
 - **Word Count**: Subtle indicator in bottom-right corner
 - **Toolbar Auto-hide**: Opt-in auto-hide after 3s of inactivity, reveal on hover
+- **Export to DOCX**: One-click export to Word `.docx` via `mdast2docx`. Preserves headings, lists, tables, code blocks, and images (inline mermaid diagrams rendered as PNG). Respects the active editor font.
+- **Export to PDF**: WYSIWYG export via headless Chromium (`puppeteer-core`). Requires Chrome, Edge, Chromium, or Brave installed locally (not bundled). Auto-detects common install paths; override with `tuiMarkdown.chromiumPath` if needed.
 - **Configurable Font Size**: Adjust editor font size (8-32px)
 - **Configurable Heading Sizes**: Customize font sizes for H1-H6 headings (12-72px)
 
@@ -59,6 +61,7 @@ A beautiful WYSIWYG Markdown editor for VS Code powered by Tiptap.
 | `tuiMarkdown.autoRenameImages` | true | Auto rename image files when path changes in markdown |
 | `tuiMarkdown.autoDeleteImages` | true | Auto delete image files when removed from markdown (moves to Trash) |
 | `tuiMarkdown.autoHideToolbar` | false | Auto-hide toolbar when typing (show on hover) |
+| `tuiMarkdown.chromiumPath` | `""` | Absolute path to a Chrome/Edge/Chromium/Brave executable for PDF export. Leave empty to auto-detect. |
 | `tuiMarkdown.headingSizes.h1` | 32 | H1 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h2` | 28 | H2 heading font size (12-72px) |
 | `tuiMarkdown.headingSizes.h3` | 24 | H3 heading font size (12-72px) |

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -11,18 +11,23 @@ Findings surfaced incidentally by review but not caused by the triggering story.
 
 1. **Windows font path thiếu trong PDF export** — `findSystemFont` trong `src/utils/export-pdf.ts` không có `C:\Windows\Fonts`. Trên Windows, user chọn font custom nhưng PDF vẫn fallback Roboto silent. Defer cho đến khi có user Windows báo lỗi.
 2. **Variable font không có Italic variant** — `italicVarFont` null dẫn đến `italicPath = varPath`, italic hiển thị như normal. Case hiếm (user có variable font không có italic), defer.
-3. **PDF inline image bị bỏ** — `imgMatch` trong `markdownToPdfContent` chỉ match image standalone đầu dòng (`^!\[`). Inline image giữa paragraph bị bỏ qua. Sẽ tự fix khi migrate parser sang AST (xem action `Migrate PDF parser to remark-parse`).
-4. **Nested list mất trong PDF** — Parser hiện tại không track indent depth. List lồng thành list phẳng. Tự fix khi migrate AST.
-5. **Table cell escape `\|` và `<br>` multiline sai** — `parseRow` split raw theo `|`. Cell có `\|` bị split sai, cell có `<br>` in literal. Tự fix khi migrate AST.
-6. **Heading `#######` (7 dấu `#`) parse sai** — Regex `#{1,6}` match 6 đầu, còn lại vào text. Hiếm.
-7. **Code block không đóng nuốt phần còn lại** — `while (!lines[i].startsWith("\`\`\`"))` chạy đến EOF. Hiếm, nhưng nên clamp.
-8. **`parseInline` không hỗ trợ escape `\*`, `\[`** — Text `\*not bold\*` thành italic sai. Tự fix khi migrate AST.
-9. **Link URL chứa `)` bị cắt** — Regex `\(([^)]+)\)` dừng ở `)` đầu tiên. Case `[text](https://en.wikipedia.org/wiki/Foo_(disambiguation))` mất đuôi. Tự fix khi migrate AST.
-10. **ELK layout áp cho non-flowchart diagram** — `mermaid.initialize({ layout: "elk" })` global, áp cho cả sequence/class/ER. ELK có thể fallback nội bộ nhưng không rollback `elkAvailable` khi render runtime fail.
-11. **`copyFonts()` crash nếu node_modules chưa cài** — Build bị crash với error khó hiểu cho contributor mới. Thêm try/catch.
-12. **Pipeline MDAST thống nhất cho DOCX + PDF** — Webview nên gửi MDAST + image map thay vì markdown text + regex replace. Giải quyết CRLF mismatch, duplicate mermaid, base64 regex O(N*M). Effort ~1 ngày, defer để tránh scope creep.
-13. **Đánh giá migrate PDF sang puppeteer-core dùng VS Code Electron** — WYSIWYG thực sự với CSS theme, bỏ parser hoàn toàn. PoC riêng, defer dài hạn.
-14. **Migrate `@m2d/md2docx@0.0.1` sang `mdast2docx@1.6.1` trực tiếp hoặc `docx@9.6.1`** — Phần wrapper của `@m2d/md2docx` chỉ ~12KB code và version 0.0.1 là alpha. Sau khi áp patch ghim version, đánh giá migrate.
+3. **ELK layout áp cho non-flowchart diagram** — `mermaid.initialize({ layout: "elk" })` global, áp cho cả sequence/class/ER. ELK có thể fallback nội bộ nhưng không rollback `elkAvailable` khi render runtime fail.
+4. **`copyFonts()` crash nếu node_modules chưa cài** — Build bị crash với error khó hiểu cho contributor mới. Thêm try/catch.
+
+### Resolved in PR #50
+
+Items below were originally deferred but resolved by the export rewrite:
+
+- ~~PDF inline image bị bỏ~~ — resolved: puppeteer-core renders HTML natively.
+- ~~Nested list mất trong PDF~~ — resolved: remark-rehype handles nested lists.
+- ~~Table cell escape `\|` và `<br>` multiline sai~~ — resolved: remark-gfm parses correctly.
+- ~~Heading `#######` (7 dấu `#`) parse sai~~ — resolved: remark-parse handles.
+- ~~Code block không đóng nuốt phần còn lại~~ — resolved: remark-parse handles.
+- ~~`parseInline` không hỗ trợ escape `\*`, `\[`~~ — resolved: remark-parse handles.
+- ~~Link URL chứa `)` bị cắt~~ — resolved: remark-parse handles.
+- ~~Pipeline MDAST thống nhất cho DOCX + PDF~~ — resolved: `markdown-ast.ts` shared pipeline.
+- ~~Đánh giá migrate PDF sang puppeteer-core~~ — resolved: Stage 4 complete.
+- ~~Migrate `@m2d/md2docx@0.0.1` sang `mdast2docx@1.6.1`~~ — resolved: Stage 2 complete.
 
 ## Deferred from: code review of plan-export-rewrite-overview (2026-04-22, pass 2)
 

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -7,6 +7,23 @@ Findings surfaced incidentally by review but not caused by the triggering story.
 1. **Screen reader feedback cho trạng thái "copied"** — `.mermaid-copy-btn` và `#lightbox-copy` chỉ đổi icon visual khi copy thành công. Nên thêm `aria-live="polite"` region hoặc đổi `aria-label` tạm thành "Copied" trong 1.5s để screen reader thông báo. Surfaced by blind-hunter review spec-mermaid-copy-image.
 2. **Refactor duplicate copy flow** — mermaid-plugin.ts và image-lightbox-plugin.ts cùng implement pattern `svgToPngBlob → copyPngBlobToClipboard → flashCopied → reportCopyError`. Có thể gom thành helper `copySvgAsPng(button, getSvgMarkup)` trong svg-to-png.ts. Surfaced by blind-hunter review spec-mermaid-copy-image.
 
+## Deferred from: code review (2026-04-22) — Fix mermaid layout + Export DOCX/PDF
+
+1. **Windows font path thiếu trong PDF export** — `findSystemFont` trong `src/utils/export-pdf.ts` không có `C:\Windows\Fonts`. Trên Windows, user chọn font custom nhưng PDF vẫn fallback Roboto silent. Defer cho đến khi có user Windows báo lỗi.
+2. **Variable font không có Italic variant** — `italicVarFont` null dẫn đến `italicPath = varPath`, italic hiển thị như normal. Case hiếm (user có variable font không có italic), defer.
+3. **PDF inline image bị bỏ** — `imgMatch` trong `markdownToPdfContent` chỉ match image standalone đầu dòng (`^!\[`). Inline image giữa paragraph bị bỏ qua. Sẽ tự fix khi migrate parser sang AST (xem action `Migrate PDF parser to remark-parse`).
+4. **Nested list mất trong PDF** — Parser hiện tại không track indent depth. List lồng thành list phẳng. Tự fix khi migrate AST.
+5. **Table cell escape `\|` và `<br>` multiline sai** — `parseRow` split raw theo `|`. Cell có `\|` bị split sai, cell có `<br>` in literal. Tự fix khi migrate AST.
+6. **Heading `#######` (7 dấu `#`) parse sai** — Regex `#{1,6}` match 6 đầu, còn lại vào text. Hiếm.
+7. **Code block không đóng nuốt phần còn lại** — `while (!lines[i].startsWith("\`\`\`"))` chạy đến EOF. Hiếm, nhưng nên clamp.
+8. **`parseInline` không hỗ trợ escape `\*`, `\[`** — Text `\*not bold\*` thành italic sai. Tự fix khi migrate AST.
+9. **Link URL chứa `)` bị cắt** — Regex `\(([^)]+)\)` dừng ở `)` đầu tiên. Case `[text](https://en.wikipedia.org/wiki/Foo_(disambiguation))` mất đuôi. Tự fix khi migrate AST.
+10. **ELK layout áp cho non-flowchart diagram** — `mermaid.initialize({ layout: "elk" })` global, áp cho cả sequence/class/ER. ELK có thể fallback nội bộ nhưng không rollback `elkAvailable` khi render runtime fail.
+11. **`copyFonts()` crash nếu node_modules chưa cài** — Build bị crash với error khó hiểu cho contributor mới. Thêm try/catch.
+12. **Pipeline MDAST thống nhất cho DOCX + PDF** — Webview nên gửi MDAST + image map thay vì markdown text + regex replace. Giải quyết CRLF mismatch, duplicate mermaid, base64 regex O(N*M). Effort ~1 ngày, defer để tránh scope creep.
+13. **Đánh giá migrate PDF sang puppeteer-core dùng VS Code Electron** — WYSIWYG thực sự với CSS theme, bỏ parser hoàn toàn. PoC riêng, defer dài hạn.
+14. **Migrate `@m2d/md2docx@0.0.1` sang `mdast2docx@1.6.1` trực tiếp hoặc `docx@9.6.1`** — Phần wrapper của `@m2d/md2docx` chỉ ~12KB code và version 0.0.1 là alpha. Sau khi áp patch ghim version, đánh giá migrate.
+
 ## Mermaid plugin — pre-existing issues
 
 1. **Stale lightbox snapshot on doc edit** — If user edits mermaid code while fullscreen lightbox is open, the lightbox keeps showing the snapshot captured at click time. Nice-to-have: close lightbox on `docChanged` when the underlying mermaid block changes, or re-render from the current block.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -24,6 +24,13 @@ Findings surfaced incidentally by review but not caused by the triggering story.
 13. **Đánh giá migrate PDF sang puppeteer-core dùng VS Code Electron** — WYSIWYG thực sự với CSS theme, bỏ parser hoàn toàn. PoC riêng, defer dài hạn.
 14. **Migrate `@m2d/md2docx@0.0.1` sang `mdast2docx@1.6.1` trực tiếp hoặc `docx@9.6.1`** — Phần wrapper của `@m2d/md2docx` chỉ ~12KB code và version 0.0.1 là alpha. Sau khi áp patch ghim version, đánh giá migrate.
 
+## Deferred from: code review of plan-export-rewrite-overview (2026-04-22, pass 2)
+
+1. **Chromium process orphan nếu `launch` throw sau fork** — `src/utils/export-pdf.ts:581-604`. Nếu `puppeteer.launch` succeed tạo process Chrome nhưng throw trước khi return, `finally` không close vì `browser` chưa được gán. Puppeteer thường tự cleanup qua SIGCHLD, nhưng không guaranteed. Hyper-edge, defer cho đến khi có report zombie process thực tế.
+2. **Document > 500KB có thể OOM Chromium khi render HTML** — `src/utils/export-pdf.ts:590-599`. `page.setContent` với HTML cực dài + nhiều inline base64 image có thể OOM. Đã có MAX_FILE_SIZE warning tại bước open (500KB, warning only không block). Fix đầy đủ cần: (a) streaming HTML, (b) chunk export theo trang. Defer tới khi có user bug report.
+3. **`mermaidImages` postMessage không chunk, IPC size unlimited** — `src/webview/main.ts:1411-1431`. 50 mermaid × 2MB PNG base64 → payload 100MB qua `vscode.postMessage`. Có thể crash webview hoặc extension host. Fix: chunk hoặc stream via `vscode.workspace.fs.writeFile` tạm rồi đọc lại. Edge case hiếm, defer.
+4. **Save dialog chọn file đang mở bởi Word/Acrobat (Windows `EBUSY`)** — `src/utils/export-docx.ts:415`, `src/utils/export-pdf.ts:600`. VS Code error `EBUSY` đã khá rõ nhưng không hint user đóng app đang lock file. Defer tới khi có feedback.
+
 ## Mermaid plugin — pre-existing issues
 
 1. **Stale lightbox snapshot on doc edit** — If user edits mermaid code while fullscreen lightbox is open, the lightbox keeps showing the snapshot captured at click time. Nice-to-have: close lightbox on `docChanged` when the underlying mermaid block changes, or re-render from the current block.

--- a/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
+++ b/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
@@ -29,12 +29,12 @@ Stage 1 (độc lập)          Stage 2 (độc lập)
 
 ## Danh sách file plan
 
-| Stage | File | Effort | Risk |
-|---|---|---|---|
-| 1 | [plan-stage-1-quick-patches.md](plan-stage-1-quick-patches.md) | 30-45 phút | Thấp |
-| 2 | [plan-stage-2-mdast2docx-migration.md](plan-stage-2-mdast2docx-migration.md) | 2-3 giờ | Trung bình |
-| 3 | [plan-stage-3-mdast-pipeline.md](plan-stage-3-mdast-pipeline.md) | 4-5 giờ | Trung bình-cao |
-| 4 | [plan-stage-4-puppeteer-pdf.md](plan-stage-4-puppeteer-pdf.md) | 8-12 giờ | Cao |
+| Stage | File | Effort | Risk | Status |
+|---|---|---|---|---|
+| 1 | [plan-stage-1-quick-patches.md](plan-stage-1-quick-patches.md) | 30-45 phút | Thấp | Done |
+| 2 | [plan-stage-2-mdast2docx-migration.md](plan-stage-2-mdast2docx-migration.md) | 2-3 giờ | Trung bình | Done |
+| 3 | [plan-stage-3-mdast-pipeline.md](plan-stage-3-mdast-pipeline.md) | 4-5 giờ | Trung bình-cao | Done |
+| 4 | [plan-stage-4-puppeteer-pdf.md](plan-stage-4-puppeteer-pdf.md) | 8-12 giờ | Cao | Done |
 
 **Tổng**: ~2 ngày làm liên tục, hoặc 1 tuần part-time.
 
@@ -72,3 +72,56 @@ Mỗi stage commit riêng. Nếu stage N fail:
 - Điều tra, fix plan, thử lại
 
 Không force-push, không rebase commit đã push.
+
+## Review Findings (2026-04-22)
+
+Code review pass 2 (adversarial 3 layers: Blind Hunter + Edge Case Hunter + Acceptance Auditor) trên diff `origin/main...develop + uncommitted`, Group A+B (core code + build config), 9 files, +855/-17.
+
+### Decision resolved
+
+- **M4 → Patch**: Giữ `"loose"`, update CLAUDE.md Lightbox section + thêm security risk note trong Mermaid section.
+- **M5 → Patch**: Conditional `--no-sandbox` chỉ khi Linux + root (`process.platform === 'linux' && process.getuid?.() === 0`).
+- **M33 → Dismiss**: Accepted risk (trusted content model, user open file tự tin tưởng).
+- **M43 → Patch (docs only)**: Giữ bundle inline, update `plan-stage-4-puppeteer-pdf.md` Done criteria hợp thức hoá 2.5MB + update task 4 bundle strategy.
+
+### Patch — High
+
+- [x] [Review][Patch] **M1 — Frontmatter regex nuốt `---` nội dung** [src/markdownEditorProvider.ts:155-156]. Regex `/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/` match cả pair `---` đầu document dù không phải frontmatter. Fix: dùng `remark-frontmatter` parse trên raw markdown (đã có trong pipeline), bỏ regex strip.
+- [x] [Review][Patch] **M3 — hashMermaidCode drift webview/extension** [src/webview/mermaid-plugin.ts:294,305 + src/utils/markdown-ast.ts:32-39]. Webview hash `node.textContent.trim()` (ProseMirror); extension hash `node.value` từ remark-parse. Line-ending (CRLF/LF) và indent (indented fence) có thể khác. Fix: normalize cả 2 bên về LF + strip leading indent, thêm test CRLF + indented fence.
+- [x] [Review][Patch] **M9 — Export button 3s debounce không track completion** [src/webview/main.ts:1433-1436]. Export PDF/DOCX lớn > 3s → click lần 2 mở 2 save dialog + 2 Chromium instance. Fix: extension gửi `exportDone` message back, hoặc extension reject duplicate request khi `exportInProgress`.
+- [x] [Review][Patch] **M13 — DOCX fetch remote không timeout, không max size** [src/utils/export-docx.ts:463-469]. `![](http://slow.host/huge.bin)` treo vô hạn + OOM. Fix: AbortController timeout 30s + kiểm `content-length` < 10MB.
+- [x] [Review][Patch] **M14 — PDF không resolve relative image** [src/utils/export-pdf.ts:59-92]. `baseDir` được compute rồi `void baseDir`. Chromium load `<img src="./img.png">` từ `about:blank` → 404 silent. Fix: inject `<base href="file://${baseDir}/">` hoặc thay resolver inline base64 như DOCX path.
+
+### Patch — Medium
+
+- [x] [Review][Patch] **M6 — `allowDangerousHtml` + script/iframe/meta-refresh passthrough** [src/utils/export-pdf.ts:645,650]. `setJavaScriptEnabled(false)` chặn JS execution, nhưng `<iframe src="file://...">`, `<link rel="stylesheet" href="file://...">`, `<meta http-equiv="refresh">` vẫn có thể fetch local resource. Fix: thêm `rehype-sanitize` với whitelist tags safe (svg, foreignObject, div, span, br, img, a, h1-6, p, pre, code, table…).
+- [x] [Review][Patch] **M7 — `userFont` escape HTML trong CSS context phá font** [src/utils/export-pdf.ts:661-665]. `escapeHtml` đổi `"` → `&quot;`, nhưng `<style>` là raw text, CSS không decode → `font-family` invalid, fallback mặc định. Fix: strip hoặc whitelist ký tự `[A-Za-z0-9 _-]`, không dùng `escapeHtml`.
+- [x] [Review][Patch] **M11 — `imageSize` catch silent → ảnh 600×400 méo tỉ lệ** [src/utils/export-docx.ts:486-494]. Fix: console.warn khi fail, log URL ảnh.
+- [x] [Review][Patch] **M12 — `decodeURIComponent` throw URIError với `%` literal** [src/utils/export-docx.ts:475]. `50%_off.png` → URIError → toàn bộ export fail. Fix: try/catch, fallback raw path.
+- [x] [Review][Patch] **M15 — `waitUntil: "load"` có thể fire trước khi img xong** [src/utils/export-pdf.ts:591]. Fix: `networkidle0` hoặc await `Promise.all(imgs.map(img => img.complete ? null : new Promise(res => img.onload = img.onerror = res)))`.
+- [x] [Review][Patch] **M17 — Async IIFE export không dispose khi webview đóng** [src/markdownEditorProvider.ts:928-957]. Fix: track `CancellationTokenSource`, listen `webviewPanel.onDidDispose`, abort puppeteer/mdast2docx.
+- [x] [Review][Patch] **M24 — Chromium cache không invalidate khi user đổi `chromiumPath`** [src/utils/chromium-discovery.ts:19-52]. Fix: thêm `vscode.workspace.onDidChangeConfiguration(e => if (e.affectsConfiguration("tuiMarkdown.chromiumPath")) clearChromiumCache())`.
+- [x] [Review][Patch] **M25 — Document trống/chỉ có frontmatter → export file trắng silent** [src/markdownEditorProvider.ts:924-956]. Fix: nếu `bodyMarkdown.trim()` rỗng → `showWarningMessage("Document trống, không có nội dung để export")` + return.
+- [x] [Review][Patch] **M28 — Puppeteer launch fail error cryptic** [src/utils/export-pdf.ts:581-585]. Fix: try/catch quanh `puppeteer.launch`, wrap error thành "Không launch được Chromium tại `<path>`: <original error>. Kiểm tra quyền execute hoặc set `tuiMarkdown.chromiumPath`".
+- [x] [Review][Patch] **M31 — `svgToPngBlob` zero dimensions throw → mermaid thiếu trong export silent** [src/webview/svg-to-png.ts:34-37]. Fix: nếu viewBox + attribute đều thiếu, fallback `{width: 800, height: 600}` và log warning.
+- [x] [Review][Patch] **M34 — DOCX ảnh local không tồn tại → toàn bộ export fail** [src/utils/export-docx.ts:476]. Fix: try/catch quanh `fs.readFile`, trả về placeholder image (empty buffer hoặc 1x1 png) và log warning thay vì throw.
+- [x] [Review][Patch] **M36 — DOCX gặp image SVG (không phải mermaid) → toàn bộ export fail** [src/utils/export-docx.ts:481-483]. Fix: return placeholder + warn, không throw.
+
+### Patch — Low
+
+- [x] [Review][Patch] **M2 — Double-strip frontmatter (regex + remark-frontmatter)** [src/markdownEditorProvider.ts:155 + src/utils/markdown-ast.ts:14]. Redundant. Fix gộp cùng M1: bỏ regex, để remark-frontmatter handle.
+- [x] [Review][Patch] **M16 — `rehype-highlight` `detect: true` chậm với document lớn** [src/utils/export-pdf.ts:646]. Fix: `detect: false` (chỉ highlight khi có language), hoặc subset languages.
+- [x] [Review][Patch] **M22 — `chromiumPath` chỉ check `isFile()`, không check execute bit** [src/utils/chromium-discovery.ts:54-61]. Fix: `fs.promises.access(path, fs.constants.X_OK)`.
+- [x] [Review][Patch] **M29 — `chromiumPath.trim()` không strip quote** [src/utils/chromium-discovery.ts:30-35]. User paste `"C:\path\chrome.exe"` → `statSync` fail. Fix: `.replace(/^["']|["']$/g, "")` trước stat.
+- [x] [Review][Patch] **M40 — "Open Folder" dùng `openExternal(folder)` behavior varies cross-platform** [src/utils/export-*.ts]. Fix: `vscode.commands.executeCommand("revealFileInOS", saveUri)`.
+
+### Deferred
+
+- [x] [Review][Defer] **M21 — Chromium process orphan nếu `launch` throw sau fork** [src/utils/export-pdf.ts:581-604] — deferred, puppeteer thường tự cleanup, rất hiếm.
+- [x] [Review][Defer] **M26 — Document > 500KB có thể OOM Chromium** [src/utils/export-pdf.ts:590-599] — deferred, đã có MAX_FILE_SIZE warning tại bước open, pre-existing.
+- [x] [Review][Defer] **M32 — `mermaidImages` postMessage không chunk, 50 diagrams × 2MB → 100MB IPC** [src/webview/main.ts:1411-1431] — deferred, edge case hiếm, optimization tương lai.
+- [x] [Review][Defer] **M38 — Save dialog chọn file đang mở bởi Word/Acrobat** [src/utils/export-docx.ts:415] — deferred, VS Code error `EBUSY` đã đủ rõ.
+
+### Dismissed (12)
+
+M8 (ELK silent try/catch — đã có console.warn), M10 (`SKIP` no-op harmless), M18 (Mermaid alt cứng — accessibility acceptable), M19 (require dynamic — build responsibility), M20 (dagre cfg warning — harmless), M27 (UTF-16 BOM — VSCode normalize), M30 (`\n`→`<br/>` trong bracket — intentional feature), M35 (DOCX font state trusted), M37 (filename no ext — minor UX), M39 (disk full — VSCode handle), M41 (getState type — internal trusted), M42 (font control char — sanitizeFontName), M44 (Stage 4 commit timing — pre-commit review OK).

--- a/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
+++ b/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
@@ -1,0 +1,74 @@
+# Overview — Export Rewrite (4 Stages)
+
+**Context**: Code review phát hiện nợ kỹ thuật và cơ hội tối ưu trong feature Export DOCX/PDF mới thêm.
+**Review date**: 2026-04-22
+**Branch**: develop
+
+## Quyết định kiến trúc
+
+| Decision | Chọn | Lý do |
+|---|---|---|
+| D1: Mermaid `securityLevel: "loose"` | **Giữ nguyên** | Chấp nhận risk để ELK + foreignObject render đẹp. Document risk này trong CLAUDE.md. |
+| D2: `@m2d/md2docx@0.0.1` | **Migrate `mdast2docx@1.6.1`** | Bỏ wrapper solo author, dùng lib lõi stable hơn. |
+| D3: PDF engine | **Rewrite với `puppeteer-core`** | WYSIWYG thật, bỏ parser tự viết 339 dòng. |
+| D4: Mermaid pipeline | **MDAST-based** | Thay regex replace fragile bằng AST visitor. |
+
+## Thứ tự thực hiện khuyến nghị
+
+```
+Stage 1 (độc lập)          Stage 2 (độc lập)
+      ↓                          ↓
+       ───────────┬──────────────
+                  ↓
+             Stage 3 (cần Stage 2)
+                  ↓
+             Stage 4 (cần Stage 3)
+```
+
+**Khuyến nghị**: Làm theo thứ tự 1 → 2 → 3 → 4. Mỗi stage commit riêng để rollback dễ.
+
+## Danh sách file plan
+
+| Stage | File | Effort | Risk |
+|---|---|---|---|
+| 1 | [plan-stage-1-quick-patches.md](plan-stage-1-quick-patches.md) | 30-45 phút | Thấp |
+| 2 | [plan-stage-2-mdast2docx-migration.md](plan-stage-2-mdast2docx-migration.md) | 2-3 giờ | Trung bình |
+| 3 | [plan-stage-3-mdast-pipeline.md](plan-stage-3-mdast-pipeline.md) | 4-5 giờ | Trung bình-cao |
+| 4 | [plan-stage-4-puppeteer-pdf.md](plan-stage-4-puppeteer-pdf.md) | 8-12 giờ | Cao |
+
+**Tổng**: ~2 ngày làm liên tục, hoặc 1 tuần part-time.
+
+## Tổng kết findings được giải quyết
+
+### Fix trực tiếp
+- Stage 1: BOM frontmatter, await doExport, debounce Export, mermaid label regex
+- Stage 2: Bỏ risk version 0.0.1
+- Stage 3: CRLF mismatch, duplicate mermaid, O(N*M) base64 regex, DOCX/PDF cùng AST
+- Stage 4: Parser limitations (nested list, link `)`, table `<br>`/`\|`, inline image, escape `\*`, code block chưa đóng, heading >6 #), WYSIWYG
+
+### Defer sang sau
+Xem [deferred-work.md](deferred-work.md) → section "Deferred from: code review (2026-04-22)".
+
+## Gotchas quan trọng
+
+1. **Stage 4 PoC sớm**: Verify `puppeteer-core` có chạy được với `process.execPath` (VS Code Electron) hay phải rely system Chrome. Test 30 phút trước khi commit toàn bộ rewrite.
+2. **Bundle VSIX**: Stage 4 thêm `node_modules/puppeteer-core` ~10MB. Check `.vscodeignore` không ignore nhầm. Stage 2 bỏ Roboto font (~768KB). Net tăng ~9MB.
+3. **Security trong Stage 4**: `setContent` + `allowDangerousHtml` có thể XSS. Disable JS trong Chromium headless hoặc dùng `rehype-sanitize` whitelist.
+4. **Stage 3 hash mermaid code**: Webview và extension PHẢI hash giống nhau. Recommend gửi raw code, hash chỉ ở extension side để tránh drift.
+
+## Verify cuối cùng sau cả 4 stage
+
+```bash
+npm run lint
+npm run build
+npm run package  # tạo VSIX
+# Manual test: Export DOCX và PDF với file phức tạp (heading, table, code, mermaid, image)
+```
+
+## Rollback plan
+
+Mỗi stage commit riêng. Nếu stage N fail:
+- `git revert <commit-N>` → giữ nguyên stage 1..N-1
+- Điều tra, fix plan, thử lại
+
+Không force-push, không rebase commit đã push.

--- a/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
+++ b/_bmad-output/implementation-artifacts/plan-export-rewrite-overview.md
@@ -15,7 +15,7 @@
 
 ## Thứ tự thực hiện khuyến nghị
 
-```
+```text
 Stage 1 (độc lập)          Stage 2 (độc lập)
       ↓                          ↓
        ───────────┬──────────────
@@ -86,41 +86,41 @@ Code review pass 2 (adversarial 3 layers: Blind Hunter + Edge Case Hunter + Acce
 
 ### Patch — High
 
-- [x] [Review][Patch] **M1 — Frontmatter regex nuốt `---` nội dung** [src/markdownEditorProvider.ts:155-156]. Regex `/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/` match cả pair `---` đầu document dù không phải frontmatter. Fix: dùng `remark-frontmatter` parse trên raw markdown (đã có trong pipeline), bỏ regex strip.
-- [x] [Review][Patch] **M3 — hashMermaidCode drift webview/extension** [src/webview/mermaid-plugin.ts:294,305 + src/utils/markdown-ast.ts:32-39]. Webview hash `node.textContent.trim()` (ProseMirror); extension hash `node.value` từ remark-parse. Line-ending (CRLF/LF) và indent (indented fence) có thể khác. Fix: normalize cả 2 bên về LF + strip leading indent, thêm test CRLF + indented fence.
-- [x] [Review][Patch] **M9 — Export button 3s debounce không track completion** [src/webview/main.ts:1433-1436]. Export PDF/DOCX lớn > 3s → click lần 2 mở 2 save dialog + 2 Chromium instance. Fix: extension gửi `exportDone` message back, hoặc extension reject duplicate request khi `exportInProgress`.
-- [x] [Review][Patch] **M13 — DOCX fetch remote không timeout, không max size** [src/utils/export-docx.ts:463-469]. `![](http://slow.host/huge.bin)` treo vô hạn + OOM. Fix: AbortController timeout 30s + kiểm `content-length` < 10MB.
-- [x] [Review][Patch] **M14 — PDF không resolve relative image** [src/utils/export-pdf.ts:59-92]. `baseDir` được compute rồi `void baseDir`. Chromium load `<img src="./img.png">` từ `about:blank` → 404 silent. Fix: inject `<base href="file://${baseDir}/">` hoặc thay resolver inline base64 như DOCX path.
+- [x] \[Review\]\[Patch\] **M1 — Frontmatter regex nuốt `---` nội dung** [src/markdownEditorProvider.ts:155-156]. Regex `/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/` match cả pair `---` đầu document dù không phải frontmatter. Fix: dùng `remark-frontmatter` parse trên raw markdown (đã có trong pipeline), bỏ regex strip.
+- [x] \[Review\]\[Patch\] **M3 — hashMermaidCode drift webview/extension** [src/webview/mermaid-plugin.ts:294,305 + src/utils/markdown-ast.ts:32-39]. Webview hash `node.textContent.trim()` (ProseMirror); extension hash `node.value` từ remark-parse. Line-ending (CRLF/LF) và indent (indented fence) có thể khác. Fix: normalize cả 2 bên về LF + strip leading indent, thêm test CRLF + indented fence.
+- [x] \[Review\]\[Patch\] **M9 — Export button 3s debounce không track completion** [src/webview/main.ts:1433-1436]. Export PDF/DOCX lớn > 3s → click lần 2 mở 2 save dialog + 2 Chromium instance. Fix: extension gửi `exportDone` message back, hoặc extension reject duplicate request khi `exportInProgress`.
+- [x] \[Review\]\[Patch\] **M13 — DOCX fetch remote không timeout, không max size** [src/utils/export-docx.ts:463-469]. `![](http://slow.host/huge.bin)` treo vô hạn + OOM. Fix: AbortController timeout 30s + kiểm `content-length` < 10MB.
+- [x] \[Review\]\[Patch\] **M14 — PDF không resolve relative image** [src/utils/export-pdf.ts:59-92]. `baseDir` được compute rồi `void baseDir`. Chromium load `<img src="./img.png">` từ `about:blank` → 404 silent. Fix: inject `<base href="file://${baseDir}/">` hoặc thay resolver inline base64 như DOCX path.
 
 ### Patch — Medium
 
-- [x] [Review][Patch] **M6 — `allowDangerousHtml` + script/iframe/meta-refresh passthrough** [src/utils/export-pdf.ts:645,650]. `setJavaScriptEnabled(false)` chặn JS execution, nhưng `<iframe src="file://...">`, `<link rel="stylesheet" href="file://...">`, `<meta http-equiv="refresh">` vẫn có thể fetch local resource. Fix: thêm `rehype-sanitize` với whitelist tags safe (svg, foreignObject, div, span, br, img, a, h1-6, p, pre, code, table…).
-- [x] [Review][Patch] **M7 — `userFont` escape HTML trong CSS context phá font** [src/utils/export-pdf.ts:661-665]. `escapeHtml` đổi `"` → `&quot;`, nhưng `<style>` là raw text, CSS không decode → `font-family` invalid, fallback mặc định. Fix: strip hoặc whitelist ký tự `[A-Za-z0-9 _-]`, không dùng `escapeHtml`.
-- [x] [Review][Patch] **M11 — `imageSize` catch silent → ảnh 600×400 méo tỉ lệ** [src/utils/export-docx.ts:486-494]. Fix: console.warn khi fail, log URL ảnh.
-- [x] [Review][Patch] **M12 — `decodeURIComponent` throw URIError với `%` literal** [src/utils/export-docx.ts:475]. `50%_off.png` → URIError → toàn bộ export fail. Fix: try/catch, fallback raw path.
-- [x] [Review][Patch] **M15 — `waitUntil: "load"` có thể fire trước khi img xong** [src/utils/export-pdf.ts:591]. Fix: `networkidle0` hoặc await `Promise.all(imgs.map(img => img.complete ? null : new Promise(res => img.onload = img.onerror = res)))`.
-- [x] [Review][Patch] **M17 — Async IIFE export không dispose khi webview đóng** [src/markdownEditorProvider.ts:928-957]. Fix: track `CancellationTokenSource`, listen `webviewPanel.onDidDispose`, abort puppeteer/mdast2docx.
-- [x] [Review][Patch] **M24 — Chromium cache không invalidate khi user đổi `chromiumPath`** [src/utils/chromium-discovery.ts:19-52]. Fix: thêm `vscode.workspace.onDidChangeConfiguration(e => if (e.affectsConfiguration("tuiMarkdown.chromiumPath")) clearChromiumCache())`.
-- [x] [Review][Patch] **M25 — Document trống/chỉ có frontmatter → export file trắng silent** [src/markdownEditorProvider.ts:924-956]. Fix: nếu `bodyMarkdown.trim()` rỗng → `showWarningMessage("Document trống, không có nội dung để export")` + return.
-- [x] [Review][Patch] **M28 — Puppeteer launch fail error cryptic** [src/utils/export-pdf.ts:581-585]. Fix: try/catch quanh `puppeteer.launch`, wrap error thành "Không launch được Chromium tại `<path>`: <original error>. Kiểm tra quyền execute hoặc set `tuiMarkdown.chromiumPath`".
-- [x] [Review][Patch] **M31 — `svgToPngBlob` zero dimensions throw → mermaid thiếu trong export silent** [src/webview/svg-to-png.ts:34-37]. Fix: nếu viewBox + attribute đều thiếu, fallback `{width: 800, height: 600}` và log warning.
-- [x] [Review][Patch] **M34 — DOCX ảnh local không tồn tại → toàn bộ export fail** [src/utils/export-docx.ts:476]. Fix: try/catch quanh `fs.readFile`, trả về placeholder image (empty buffer hoặc 1x1 png) và log warning thay vì throw.
-- [x] [Review][Patch] **M36 — DOCX gặp image SVG (không phải mermaid) → toàn bộ export fail** [src/utils/export-docx.ts:481-483]. Fix: return placeholder + warn, không throw.
+- [x] \[Review\]\[Patch\] **M6 — `allowDangerousHtml` + script/iframe/meta-refresh passthrough** [src/utils/export-pdf.ts:645,650]. `setJavaScriptEnabled(false)` chặn JS execution, nhưng `<iframe src="file://...">`, `<link rel="stylesheet" href="file://...">`, `<meta http-equiv="refresh">` vẫn có thể fetch local resource. Fix: thêm `rehype-sanitize` với whitelist tags safe (svg, foreignObject, div, span, br, img, a, h1-6, p, pre, code, table…).
+- [x] \[Review\]\[Patch\] **M7 — `userFont` escape HTML trong CSS context phá font** [src/utils/export-pdf.ts:661-665]. `escapeHtml` đổi `"` → `&quot;`, nhưng `<style>` là raw text, CSS không decode → `font-family` invalid, fallback mặc định. Fix: strip hoặc whitelist ký tự `[A-Za-z0-9 _-]`, không dùng `escapeHtml`.
+- [x] \[Review\]\[Patch\] **M11 — `imageSize` catch silent → ảnh 600×400 méo tỉ lệ** [src/utils/export-docx.ts:486-494]. Fix: console.warn khi fail, log URL ảnh.
+- [x] \[Review\]\[Patch\] **M12 — `decodeURIComponent` throw URIError với `%` literal** [src/utils/export-docx.ts:475]. `50%_off.png` → URIError → toàn bộ export fail. Fix: try/catch, fallback raw path.
+- [x] \[Review\]\[Patch\] **M15 — `waitUntil: "load"` có thể fire trước khi img xong** [src/utils/export-pdf.ts:591]. Fix: `networkidle0` hoặc await `Promise.all(imgs.map(img => img.complete ? null : new Promise(res => img.onload = img.onerror = res)))`.
+- [x] \[Review\]\[Patch\] **M17 — Async IIFE export không dispose khi webview đóng** [src/markdownEditorProvider.ts:928-957]. Fix: track `CancellationTokenSource`, listen `webviewPanel.onDidDispose`, abort puppeteer/mdast2docx.
+- [x] \[Review\]\[Patch\] **M24 — Chromium cache không invalidate khi user đổi `chromiumPath`** [src/utils/chromium-discovery.ts:19-52]. Fix: thêm `vscode.workspace.onDidChangeConfiguration(e => if (e.affectsConfiguration("tuiMarkdown.chromiumPath")) clearChromiumCache())`.
+- [x] \[Review\]\[Patch\] **M25 — Document trống/chỉ có frontmatter → export file trắng silent** [src/markdownEditorProvider.ts:924-956]. Fix: nếu `bodyMarkdown.trim()` rỗng → `showWarningMessage("Document trống, không có nội dung để export")` + return.
+- [x] \[Review\]\[Patch\] **M28 — Puppeteer launch fail error cryptic** [src/utils/export-pdf.ts:581-585]. Fix: try/catch quanh `puppeteer.launch`, wrap error thành "Không launch được Chromium tại `<path>`: <original error>. Kiểm tra quyền execute hoặc set `tuiMarkdown.chromiumPath`".
+- [x] \[Review\]\[Patch\] **M31 — `svgToPngBlob` zero dimensions throw → mermaid thiếu trong export silent** [src/webview/svg-to-png.ts:34-37]. Fix: nếu viewBox + attribute đều thiếu, fallback `{width: 800, height: 600}` và log warning.
+- [x] \[Review\]\[Patch\] **M34 — DOCX ảnh local không tồn tại → toàn bộ export fail** [src/utils/export-docx.ts:476]. Fix: try/catch quanh `fs.readFile`, trả về placeholder image (empty buffer hoặc 1x1 png) và log warning thay vì throw.
+- [x] \[Review\]\[Patch\] **M36 — DOCX gặp image SVG (không phải mermaid) → toàn bộ export fail** [src/utils/export-docx.ts:481-483]. Fix: return placeholder + warn, không throw.
 
 ### Patch — Low
 
-- [x] [Review][Patch] **M2 — Double-strip frontmatter (regex + remark-frontmatter)** [src/markdownEditorProvider.ts:155 + src/utils/markdown-ast.ts:14]. Redundant. Fix gộp cùng M1: bỏ regex, để remark-frontmatter handle.
-- [x] [Review][Patch] **M16 — `rehype-highlight` `detect: true` chậm với document lớn** [src/utils/export-pdf.ts:646]. Fix: `detect: false` (chỉ highlight khi có language), hoặc subset languages.
-- [x] [Review][Patch] **M22 — `chromiumPath` chỉ check `isFile()`, không check execute bit** [src/utils/chromium-discovery.ts:54-61]. Fix: `fs.promises.access(path, fs.constants.X_OK)`.
-- [x] [Review][Patch] **M29 — `chromiumPath.trim()` không strip quote** [src/utils/chromium-discovery.ts:30-35]. User paste `"C:\path\chrome.exe"` → `statSync` fail. Fix: `.replace(/^["']|["']$/g, "")` trước stat.
-- [x] [Review][Patch] **M40 — "Open Folder" dùng `openExternal(folder)` behavior varies cross-platform** [src/utils/export-*.ts]. Fix: `vscode.commands.executeCommand("revealFileInOS", saveUri)`.
+- [x] \[Review\]\[Patch\] **M2 — Double-strip frontmatter (regex + remark-frontmatter)** [src/markdownEditorProvider.ts:155 + src/utils/markdown-ast.ts:14]. Redundant. Fix gộp cùng M1: bỏ regex, để remark-frontmatter handle.
+- [x] \[Review\]\[Patch\] **M16 — `rehype-highlight` `detect: true` chậm với document lớn** [src/utils/export-pdf.ts:646]. Fix: `detect: false` (chỉ highlight khi có language), hoặc subset languages.
+- [x] \[Review\]\[Patch\] **M22 — `chromiumPath` chỉ check `isFile()`, không check execute bit** [src/utils/chromium-discovery.ts:54-61]. Fix: `fs.promises.access(path, fs.constants.X_OK)`.
+- [x] \[Review\]\[Patch\] **M29 — `chromiumPath.trim()` không strip quote** [src/utils/chromium-discovery.ts:30-35]. User paste `"C:\path\chrome.exe"` → `statSync` fail. Fix: `.replace(/^["']|["']$/g, "")` trước stat.
+- [x] \[Review\]\[Patch\] **M40 — "Open Folder" dùng `openExternal(folder)` behavior varies cross-platform** [src/utils/export-*.ts]. Fix: `vscode.commands.executeCommand("revealFileInOS", saveUri)`.
 
 ### Deferred
 
-- [x] [Review][Defer] **M21 — Chromium process orphan nếu `launch` throw sau fork** [src/utils/export-pdf.ts:581-604] — deferred, puppeteer thường tự cleanup, rất hiếm.
-- [x] [Review][Defer] **M26 — Document > 500KB có thể OOM Chromium** [src/utils/export-pdf.ts:590-599] — deferred, đã có MAX_FILE_SIZE warning tại bước open, pre-existing.
-- [x] [Review][Defer] **M32 — `mermaidImages` postMessage không chunk, 50 diagrams × 2MB → 100MB IPC** [src/webview/main.ts:1411-1431] — deferred, edge case hiếm, optimization tương lai.
-- [x] [Review][Defer] **M38 — Save dialog chọn file đang mở bởi Word/Acrobat** [src/utils/export-docx.ts:415] — deferred, VS Code error `EBUSY` đã đủ rõ.
+- [x] \[Review\]\[Defer\] **M21 — Chromium process orphan nếu `launch` throw sau fork** [src/utils/export-pdf.ts:581-604] — deferred, puppeteer thường tự cleanup, rất hiếm.
+- [x] \[Review\]\[Defer\] **M26 — Document > 500KB có thể OOM Chromium** [src/utils/export-pdf.ts:590-599] — deferred, đã có MAX_FILE_SIZE warning tại bước open, pre-existing.
+- [x] \[Review\]\[Defer\] **M32 — `mermaidImages` postMessage không chunk, 50 diagrams × 2MB → 100MB IPC** [src/webview/main.ts:1411-1431] — deferred, edge case hiếm, optimization tương lai.
+- [x] \[Review\]\[Defer\] **M38 — Save dialog chọn file đang mở bởi Word/Acrobat** [src/utils/export-docx.ts:415] — deferred, VS Code error `EBUSY` đã đủ rõ.
 
 ### Dismissed (12)
 

--- a/_bmad-output/implementation-artifacts/plan-stage-1-quick-patches.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-1-quick-patches.md
@@ -1,6 +1,6 @@
 # Plan Stage 1 — Quick Patches (bền vững)
 
-**Status**: ready
+**Status**: done (2026-04-22)
 **Estimated effort**: 30-45 phút
 **Risk**: Thấp
 **Dependencies**: Không. Làm độc lập.
@@ -23,14 +23,14 @@
 
 ### P3. Frontmatter regex skip BOM
 
-- [ ] Trong `markdownEditorProvider.ts` tìm `const frontmatterRegex = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
-- [ ] Đổi thành `const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
-- [ ] Test: tạo file `.md` có BOM (dùng `printf '\xEF\xBB\xBF---\ntitle: x\n---\n# Hello\n' > test.md`) rồi export, frontmatter phải bị strip.
+- [x] Trong `markdownEditorProvider.ts` tìm `const frontmatterRegex = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
+- [x] Đổi thành `const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
+- [x] Verify Node snippet: BOM `EF BB BF` + frontmatter strip sạch, content `# Hello` giữ nguyên.
 
 ### P5. await doExport, lỗi async không nuốt
 
-- [ ] Trong `markdownEditorProvider.ts` case `"export"`, hiện tại gọi `doExport(bodyForExport, document.uri)` không await.
-- [ ] Bọc trong IIFE async có try/catch:
+- [x] Trong `markdownEditorProvider.ts` case `"export"`, hiện tại gọi `doExport(bodyForExport, document.uri)` không await.
+- [x] Bọc trong IIFE async có try/catch:
   ```ts
   (async () => {
     try {
@@ -48,11 +48,11 @@
     }
   })();
   ```
-- [ ] Test: force lỗi bằng cách rename `out/export-pdf.js`, click Export, phải thấy dialog error thay vì silence.
+- [ ] Test: force lỗi bằng cách rename `out/export-pdf.js`, click Export, phải thấy dialog error thay vì silence. (Defer sang QA pass sau Stage 2/3.)
 
 ### P6. Debounce nút Export tránh double-click
 
-- [ ] Trong `src/webview/main.ts` handler `#btn-export-go` click:
+- [x] Trong `src/webview/main.ts` handler `#btn-export-go` click:
   ```ts
   const btn = document.getElementById("btn-export-go") as HTMLButtonElement | null;
   btn?.addEventListener("click", async () => {
@@ -66,26 +66,26 @@
     }
   });
   ```
-- [ ] Optional: extension gửi `exportComplete` message để enable sớm hơn. Không bắt buộc cho stage này.
-- [ ] Test: click Export 3 lần liên tiếp, chỉ thấy 1 save dialog.
+- [ ] Optional: extension gửi `exportComplete` message để enable sớm hơn. Không bắt buộc cho stage này. (Defer.)
+- [ ] Test: click Export 3 lần liên tiếp, chỉ thấy 1 save dialog. (Defer sang QA pass sau Stage 2/3.)
 
 ### P7. Mermaid label regex cover nhiều pattern hơn
 
-- [ ] Trong `src/webview/mermaid-plugin.ts` tìm:
+- [x] Trong `src/webview/mermaid-plugin.ts` tìm:
   ```ts
   const processed = code.replace(
       /(\["[^"]*"\]|\("[^"]*"\)|\{"[^"]*"\})/g,
       (match) => match.replace(/\\n/g, "<br/>"),
   );
   ```
-- [ ] Thay bằng cách xử lý rộng hơn. Gợi ý: process per-line, chỉ match bên trong bracket `[...]`, `(...)`, `{...}` bất kể quote style:
+- [x] Thay bằng cách xử lý rộng hơn. Gợi ý: process per-line, chỉ match bên trong bracket `[...]`, `(...)`, `{...}` bất kể quote style:
   ```ts
   const processed = code.replace(
       /(\[[^\]]*\]|\([^)]*\)|\{[^}]*\})/g,
       (match) => match.replace(/\\n/g, "<br/>"),
   );
   ```
-- [ ] Risk: regex rộng hơn có thể match `[class]` trong class diagram. Verify: test với `sequenceDiagram`, `classDiagram`, `flowchart`, `stateDiagram` sample từ mermaid docs.
+- [ ] Risk: regex rộng hơn có thể match `[class]` trong class diagram. Verify: test với `sequenceDiagram`, `classDiagram`, `flowchart`, `stateDiagram` sample từ mermaid docs. (Defer sang QA pass.)
 - [ ] Nếu gây regression: narrow lại hoặc chỉ apply trong `flowchart` block (detect qua `code.trim().startsWith("flowchart")`).
 
 ## Verify
@@ -113,7 +113,18 @@ Nếu có regression: `git revert <commit>`. Plan này làm 1 commit duy nhất.
 
 ## Done criteria
 
-- 4 patch applied
-- Build pass
-- Smoke test manual pass
-- Commit với message: `fix(export): skip BOM frontmatter, await export, debounce button, mermaid label regex`
+- [x] 4 patch applied
+- [x] `npm run lint` pass (tsc --noEmit)
+- [x] `npm run build` pass (esbuild production)
+- [x] BOM regex verify bằng Node snippet
+- [ ] Smoke test manual (rapid-click, mermaid classDiagram) — defer sang QA pass khi export thật chạy
+- [ ] Commit: `fix(export): skip BOM frontmatter, await export, debounce button, mermaid label regex` — chờ user xác nhận
+
+## Kết quả
+
+| Patch | File                                                                                            | Thay đổi                                          |
+| ----- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| P3    | [src/markdownEditorProvider.ts:926](src/markdownEditorProvider.ts#L926)                         | `frontmatterRegex` thêm `﻿?` (U+FEFF) đầu regex |
+| P5    | [src/markdownEditorProvider.ts:944-960](src/markdownEditorProvider.ts#L944-L960)                | Async IIFE + try/catch + `showErrorMessage`       |
+| P6    | [src/webview/main.ts:1402-1436](src/webview/main.ts#L1402-L1436)                                | `exportBtn.disabled` + `setTimeout` 3s re-enable  |
+| P7    | [src/webview/mermaid-plugin.ts:141-145](src/webview/mermaid-plugin.ts#L141-L145)                | Regex match mọi `[...]`, `(...)`, `{...}`         |

--- a/_bmad-output/implementation-artifacts/plan-stage-1-quick-patches.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-1-quick-patches.md
@@ -1,0 +1,119 @@
+# Plan Stage 1 — Quick Patches (bền vững)
+
+**Status**: ready
+**Estimated effort**: 30-45 phút
+**Risk**: Thấp
+**Dependencies**: Không. Làm độc lập.
+**Commit prefix**: `fix:`
+
+## Mục tiêu
+
+Áp 4 patch không liên quan kiến trúc PDF/DOCX (sẽ không bị xoá khi làm Stage 2-4).
+
+## Scope
+
+| File                                                           | Patch                     | Impact     |
+| -------------------------------------------------------------- | ------------------------- | ---------- |
+| [src/markdownEditorProvider.ts](src/markdownEditorProvider.ts) | P3 BOM + P5 await         | Trung bình |
+| [src/webview/main.ts](src/webview/main.ts)                     | P6 debounce Export button | Nhỏ        |
+| [src/webview/mermaid-plugin.ts](src/webview/mermaid-plugin.ts) | P7 regex label mở rộng    | Trung bình |
+
+
+## Tasks
+
+### P3. Frontmatter regex skip BOM
+
+- [ ] Trong `markdownEditorProvider.ts` tìm `const frontmatterRegex = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
+- [ ] Đổi thành `const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;`
+- [ ] Test: tạo file `.md` có BOM (dùng `printf '\xEF\xBB\xBF---\ntitle: x\n---\n# Hello\n' > test.md`) rồi export, frontmatter phải bị strip.
+
+### P5. await doExport, lỗi async không nuốt
+
+- [ ] Trong `markdownEditorProvider.ts` case `"export"`, hiện tại gọi `doExport(bodyForExport, document.uri)` không await.
+- [ ] Bọc trong IIFE async có try/catch:
+  ```ts
+  (async () => {
+    try {
+      if (exportFormat === "pdf") {
+        const { exportToPdf } = require(path.join(__dirname, "export-pdf.js"));
+        await exportToPdf(bodyForExport, document.uri);
+      } else {
+        const { exportToDocx } = require(path.join(__dirname, "export-docx.js"));
+        await exportToDocx(bodyForExport, document.uri);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Export thất bại: ${msg}`);
+      console.error("[Export]", err);
+    }
+  })();
+  ```
+- [ ] Test: force lỗi bằng cách rename `out/export-pdf.js`, click Export, phải thấy dialog error thay vì silence.
+
+### P6. Debounce nút Export tránh double-click
+
+- [ ] Trong `src/webview/main.ts` handler `#btn-export-go` click:
+  ```ts
+  const btn = document.getElementById("btn-export-go") as HTMLButtonElement | null;
+  btn?.addEventListener("click", async () => {
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    try {
+      // ... existing collect mermaidImages + postMessage logic
+    } finally {
+      // Re-enable sau 3s hoặc khi nhận response từ extension
+      setTimeout(() => { if (btn) btn.disabled = false; }, 3000);
+    }
+  });
+  ```
+- [ ] Optional: extension gửi `exportComplete` message để enable sớm hơn. Không bắt buộc cho stage này.
+- [ ] Test: click Export 3 lần liên tiếp, chỉ thấy 1 save dialog.
+
+### P7. Mermaid label regex cover nhiều pattern hơn
+
+- [ ] Trong `src/webview/mermaid-plugin.ts` tìm:
+  ```ts
+  const processed = code.replace(
+      /(\["[^"]*"\]|\("[^"]*"\)|\{"[^"]*"\})/g,
+      (match) => match.replace(/\\n/g, "<br/>"),
+  );
+  ```
+- [ ] Thay bằng cách xử lý rộng hơn. Gợi ý: process per-line, chỉ match bên trong bracket `[...]`, `(...)`, `{...}` bất kể quote style:
+  ```ts
+  const processed = code.replace(
+      /(\[[^\]]*\]|\([^)]*\)|\{[^}]*\})/g,
+      (match) => match.replace(/\\n/g, "<br/>"),
+  );
+  ```
+- [ ] Risk: regex rộng hơn có thể match `[class]` trong class diagram. Verify: test với `sequenceDiagram`, `classDiagram`, `flowchart`, `stateDiagram` sample từ mermaid docs.
+- [ ] Nếu gây regression: narrow lại hoặc chỉ apply trong `flowchart` block (detect qua `code.trim().startsWith("flowchart")`).
+
+## Verify
+
+```bash
+npm run lint     # tsc --noEmit phải pass
+npm run build    # esbuild phải build thành công
+```
+
+Manual smoke test:
+
+1. Tạo file `.md` có BOM + frontmatter + `flowchart TD\nA["Line1\nLine2"] --> B`.
+2. Export DOCX hoặc PDF (sau khi Stage 2/3 xong; stage này chỉ test không crash).
+3. Click Export 3 lần rapid.
+
+## Rollback
+
+Nếu có regression: `git revert <commit>`. Plan này làm 1 commit duy nhất.
+
+## Out of scope
+
+- Fix parser PDF (sẽ bỏ ở Stage 4)
+- Fix regex replace mermaid trong markdown text (sẽ bỏ ở Stage 3)
+- Fix race tmpFile PDF (sẽ bỏ ở Stage 4)
+
+## Done criteria
+
+- 4 patch applied
+- Build pass
+- Smoke test manual pass
+- Commit với message: `fix(export): skip BOM frontmatter, await export, debounce button, mermaid label regex`

--- a/_bmad-output/implementation-artifacts/plan-stage-2-mdast2docx-migration.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-2-mdast2docx-migration.md
@@ -1,0 +1,112 @@
+# Plan Stage 2 — Migrate `@m2d/md2docx@0.0.1` → `mdast2docx@1.6.1`
+
+**Status**: ready
+**Estimated effort**: 2-3 giờ
+**Risk**: Trung bình (API khác, cần test đầy đủ)
+**Dependencies**: Không phụ thuộc Stage 1. Có thể làm trước hoặc sau.
+**Commit prefix**: `refactor(export):`
+
+## Mục tiêu
+
+Bỏ wrapper `@m2d/md2docx@0.0.1` (247 weekly DL, repo 404, solo author, version 0.x alpha).
+Dùng trực tiếp `mdast2docx@1.6.1` (14K weekly DL, active, cùng tác giả) với pipeline unified.
+
+**Lý do**:
+- Wrapper chỉ ~10 dòng code, không đáng giá tradeoff lock vào version 0.0.1.
+- `mdast2docx` là lib lõi thực sự, version 1.x ổn định.
+- Chủ động hơn khi cần custom pipeline sau này (Stage 3 reuse AST).
+
+## Scope
+
+| File | Thay đổi |
+|---|---|
+| [package.json](package.json) | Remove `@m2d/md2docx`, add `mdast2docx`, `unified`, `remark-parse`, `remark-gfm`, `remark-frontmatter` |
+| [src/utils/export-docx.ts](src/utils/export-docx.ts) | Rewrite pipeline (wrapper → unified pipeline) |
+| [esbuild.config.js](esbuild.config.js) | Không thay đổi (bundle vẫn tách) |
+
+## Tasks
+
+### 1. Cập nhật dependencies
+- [ ] `npm uninstall @m2d/md2docx`
+- [ ] `npm install mdast2docx@^1.6.1 unified@^11 remark-parse@^11 remark-gfm@^4 remark-frontmatter@^5`
+- [ ] Verify: `package-lock.json` cập nhật, `node_modules/mdast2docx` tồn tại.
+
+### 2. Rewrite `src/utils/export-docx.ts`
+- [ ] Đọc docs: `node_modules/mdast2docx/README.md` hoặc `npm view mdast2docx` để xem API signature.
+- [ ] Pipeline mới:
+  ```ts
+  import { unified } from "unified";
+  import remarkParse from "remark-parse";
+  import remarkGfm from "remark-gfm";
+  import remarkFrontmatter from "remark-frontmatter";
+  import { toDocx } from "mdast2docx";  // verify export name sau khi install
+
+  async function markdownToMdast(md: string) {
+    const file = unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkFrontmatter, ["yaml"])
+      .parse(md);
+    return file;
+  }
+
+  export async function exportToDocx(markdown: string, documentUri: vscode.Uri) {
+    // ... showSaveDialog, progress ...
+    const mdast = await markdownToMdast(markdown);
+    const blob = await toDocx(mdast, { title: docName }, {});
+    const buffer = Buffer.from(await blob.arrayBuffer());
+    await vscode.workspace.fs.writeFile(saveUri, buffer);
+  }
+  ```
+- [ ] Verify `toDocx` signature qua `npm view mdast2docx` hoặc đọc `.d.ts` trong `node_modules/mdast2docx/dist/`.
+
+### 3. Test matrix
+- [ ] Heading H1-H6
+- [ ] Paragraph với **bold**, *italic*, `code`, [link](url), ~~strike~~
+- [ ] Unordered list, ordered list, task list (`- [x]`)
+- [ ] Nested list (2 level indent)
+- [ ] Code block với language tag
+- [ ] Blockquote
+- [ ] Table GFM 2-3 cột, có align, có `|` escape
+- [ ] Image local path và base64 data URL
+- [ ] Mermaid base64 inline (simulate bằng `![alt](data:image/png;base64,...)`)
+- [ ] Frontmatter strip (đã strip ở extension, mdast không thấy)
+- [ ] Horizontal rule
+- [ ] GitHub alert (`> [!NOTE]`) — có thể render thành blockquote thường, OK.
+
+### 4. Bundle size check
+- [ ] Build production: `npm run build`
+- [ ] So sánh `out/export-docx.js` size trước và sau.
+- [ ] Nếu tăng >30%, xem xét tree-shaking hoặc chỉ import subset.
+
+## Verify
+
+```bash
+npm run lint
+npm run build
+ls -lh out/export-docx.js  # ghi lại size
+```
+
+## Rollback
+
+```bash
+git revert <commit>
+npm install  # restore @m2d/md2docx from package-lock
+```
+
+## Risks
+
+- **mdast2docx API khác wrapper**: signature của `toDocx` có thể là `(mdast, options)` thay vì `(md, title, ...)`. Cần đọc type definition TRƯỚC khi viết.
+- **Image handling**: mdast2docx cần xử lý base64 data URL (mermaid PNG inline). Test sớm với 1 diagram.
+- **Bundle size**: unified + remark-* có thể thêm ~200-500KB. Chấp nhận được vì lazy-loaded.
+
+## Done criteria
+
+- [ ] DOCX export hoạt động với test matrix trên
+- [ ] Bundle size không tăng quá 30%
+- [ ] Output DOCX mở được trong Word/LibreOffice, format không vỡ
+- [ ] Commit message: `refactor(export): migrate @m2d/md2docx to mdast2docx + unified pipeline`
+
+## Follow-up (không thuộc stage này)
+
+- Stage 3 sẽ reuse hàm `markdownToMdast` này, có thể tách ra `src/utils/markdown-ast.ts`.

--- a/_bmad-output/implementation-artifacts/plan-stage-2-mdast2docx-migration.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-2-mdast2docx-migration.md
@@ -62,7 +62,7 @@ Dùng trực tiếp `mdast2docx@1.6.1` (14K weekly DL, active, cùng tác giả)
 
 ### 3. Test matrix
 - [ ] Heading H1-H6
-- [ ] Paragraph với **bold**, *italic*, `code`, [link](url), ~~strike~~
+- [ ] Paragraph với **bold**, *italic*, `code`, `[link](url)`, ~~strike~~
 - [ ] Unordered list, ordered list, task list (`- [x]`)
 - [ ] Nested list (2 level indent)
 - [ ] Code block với language tag

--- a/_bmad-output/implementation-artifacts/plan-stage-3-mdast-pipeline.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-3-mdast-pipeline.md
@@ -1,0 +1,156 @@
+# Plan Stage 3 — MDAST Pipeline (webview ↔ extension)
+
+**Status**: ready
+**Estimated effort**: 0.5 ngày (4-5 giờ)
+**Risk**: Trung bình-cao (contract giữa webview và extension thay đổi)
+**Dependencies**: Khuyến nghị làm SAU Stage 2 (có sẵn `markdownToMdast` helper)
+**Commit prefix**: `refactor(export):`
+
+## Mục tiêu
+
+Bỏ pipeline fragile hiện tại:
+```
+webview text → regex escape code mermaid → extension.replace(regex, base64 data URL)
+```
+
+Thay bằng pipeline AST:
+```
+extension parse markdown → MDAST → visitor replace code[lang=mermaid] → image node → pass MDAST cho cả exportToDocx và exportToPdf
+```
+
+**Lợi ích**:
+- Hết lỗi CRLF line ending mismatch
+- Hết O(N*M) khi document lớn + nhiều mermaid
+- DOCX và PDF dùng chung AST → output nhất quán
+- Base64 không nhét vào regex replacement string khổng lồ
+
+## Scope
+
+| File | Thay đổi |
+|---|---|
+| [src/webview/main.ts](src/webview/main.ts) | Gửi `{mermaidImages: [{codeHash, base64}]}` thay vì `{code, base64}` |
+| [src/markdownEditorProvider.ts](src/markdownEditorProvider.ts) | Case `"export"`: parse MDAST, visit replace nodes, pass MDAST xuống export funcs |
+| [src/utils/export-docx.ts](src/utils/export-docx.ts) | Accept MDAST hoặc markdown string (giữ 2 signature) |
+| [src/utils/export-pdf.ts](src/utils/export-pdf.ts) | Tạm thời nhận markdown string (Stage 4 sẽ thay bằng MDAST) |
+| [src/utils/markdown-ast.ts](src/utils/markdown-ast.ts) | **Mới**: shared helpers parse + visit MDAST |
+
+## Tasks
+
+### 1. Tạo `src/utils/markdown-ast.ts`
+- [ ] Export 2 hàm:
+  ```ts
+  export function parseMarkdownToMdast(md: string): Root;
+  export function replaceMermaidBlocks(
+    mdast: Root,
+    imageMap: Map<string, string>  // codeHash → base64 data URL
+  ): void;  // mutate in place
+  ```
+- [ ] `parseMarkdownToMdast` dùng `unified + remark-parse + remark-gfm + remark-frontmatter` (đã cài ở Stage 2).
+- [ ] `replaceMermaidBlocks` dùng `unist-util-visit` để duyệt, khi gặp `node.type === 'code' && node.lang === 'mermaid'`:
+  - Hash code (sha1 hoặc simple hash 32-bit) để match với imageMap.
+  - Nếu match: thay node thành `{type: 'image', url: dataUrl, alt: 'Mermaid Diagram'}`.
+  - Nếu không match: giữ nguyên code block (graceful degradation).
+
+### 2. Thay đổi contract webview → extension
+- [ ] Trong `src/webview/main.ts`:
+  - Hash code trước khi gửi:
+    ```ts
+    function hashString(s: string): string {
+      let h = 5381;
+      for (let i = 0; i < s.length; i++) h = ((h << 5) + h) + s.charCodeAt(i);
+      return (h >>> 0).toString(16);
+    }
+    // Hoặc dùng crypto.subtle.digest('SHA-1', ...) nếu preferred
+    ```
+  - Đổi payload postMessage:
+    ```ts
+    mermaidImages.push({ codeHash: hashString(code.trim()), base64 });
+    ```
+  - Hoặc giữ raw code (để extension hash lại, đồng bộ logic). Chọn raw code cho đơn giản, hash chỉ ở extension side.
+
+### 3. Extension handler case `"export"`
+- [ ] Trong `markdownEditorProvider.ts`:
+  ```ts
+  case "export": {
+    const rawText = document.getText();
+    const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+    const markdown = rawText.replace(frontmatterRegex, "");
+
+    const mdast = parseMarkdownToMdast(markdown);
+    const imageMap = new Map(
+      (exportMsg.mermaidImages ?? []).map(({ code, base64 }) =>
+        [hashString(code.trim()), base64]
+      )
+    );
+    replaceMermaidBlocks(mdast, imageMap);
+
+    if (exportFormat === "pdf") {
+      await exportToPdf(mdast, document.uri);  // Stage 4 sẽ accept MDAST
+    } else {
+      await exportToDocx(mdast, document.uri);
+    }
+    break;
+  }
+  ```
+- [ ] Giữ hash function đồng bộ với webview.
+
+### 4. Update `exportToDocx`
+- [ ] Accept MDAST thay vì string:
+  ```ts
+  export async function exportToDocx(
+    mdast: Root,
+    documentUri: vscode.Uri
+  ): Promise<void> {
+    // ... showSaveDialog ...
+    const blob = await toDocx(mdast, { title: docName }, {});
+    // ...
+  }
+  ```
+- [ ] Bỏ bước parse markdown → mdast trong file này (đã làm ở extension side).
+
+### 5. Stage-4 bridge cho `exportToPdf`
+- [ ] Tạm thời: convert MDAST → markdown string bằng `remark-stringify` để giữ signature cũ.
+  ```ts
+  import { unified } from "unified";
+  import remarkStringify from "remark-stringify";
+  const md = unified().use(remarkStringify).stringify(mdast) as string;
+  await exportToPdf(md, document.uri);
+  ```
+- [ ] Stage 4 sẽ bỏ bridge này, accept MDAST trực tiếp.
+
+## Verify
+
+```bash
+npm run lint
+npm run build
+```
+
+Manual test matrix:
+- [ ] File CRLF line ending (dùng `unix2dos test.md` hoặc Notepad trên Windows).
+- [ ] File có 2 mermaid block identical (duplicate code) → cả 2 đều được thay ảnh.
+- [ ] File có 5+ mermaid block lớn → không lag.
+- [ ] Mermaid render fail (syntax sai) → code block giữ nguyên trong DOCX/PDF, không crash.
+- [ ] Export DOCX và PDF từ cùng file → output structure giống nhau.
+
+## Rollback
+
+`git revert <commit>`. Plan làm 1 commit duy nhất.
+
+## Risks
+
+- **Hash collision**: probability cực thấp với djb2 32-bit cho diagram thông thường (< 1000 mermaid blocks per file). Nếu lo, dùng SHA-1 8 ký tự đầu.
+- **Webview-extension contract đổi**: nếu rollback nửa chừng, phải revert cả 2 bên. Làm 1 commit atomic.
+- **remark-stringify roundtrip**: markdown → MDAST → markdown có thể khác format gốc (khoảng cách, indent). Chấp nhận được vì chỉ dùng tạm cho Stage 4 bridge, Stage 4 sẽ bỏ.
+- **Mermaid code sau `code.trim()`**: webview trim, extension cần hash cùng `trim()`. Đồng bộ.
+
+## Done criteria
+
+- [ ] Unit hoặc manual test: CRLF file export đúng, duplicate mermaid thay đúng cả 2 lần
+- [ ] Bundle size extension.js không tăng >100KB
+- [ ] DOCX output giống Stage 2
+- [ ] Commit message: `refactor(export): MDAST pipeline, webview gửi image map thay regex replace`
+
+## Out of scope (Stage 4)
+
+- Rewrite PDF bằng puppeteer-core
+- Bỏ parser tự viết 339 dòng

--- a/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
@@ -1,0 +1,234 @@
+# Plan Stage 4 — PDF rewrite với `puppeteer-core`
+
+**Status**: ready
+**Estimated effort**: 1-1.5 ngày (8-12 giờ)
+**Risk**: Cao (Chromium discovery cross-platform, bundle footprint)
+**Dependencies**: **PHẢI làm sau Stage 3** (cần MDAST pipeline sẵn sàng)
+**Commit prefix**: `refactor(export):`
+
+## Mục tiêu
+
+Bỏ hoàn toàn:
+- `pdfmake@0.3.7` (1.1MB bundle)
+- Roboto fonts bundled (768KB)
+- `copyFonts()` trong esbuild
+- Parser markdown tự viết 339 dòng trong `export-pdf.ts`
+
+Thay bằng pipeline:
+```
+MDAST (từ Stage 3) → HTML (remark-rehype + rehype-stringify) → wrap CSS theme →
+puppeteer-core.setContent → page.pdf() → Buffer → file
+```
+
+**Lợi ích**:
+- WYSIWYG thực sự: PDF giống hệt preview editor (CSS theme, font, layout).
+- Zero parser maintenance: xoá 339 dòng tự bảo trì.
+- Syntax highlight code block, mermaid image, GitHub alert đều render đúng.
+
+**Tradeoff**:
+- Bundle `puppeteer-core` ~8.8MB (tăng so với pdfmake 1.1MB + font 768KB = 1.9MB).
+- Cold start ~1s khi launch browser.
+- Phụ thuộc Chromium trên máy user.
+
+## Scope
+
+| File | Thay đổi |
+|---|---|
+| [package.json](package.json) | Remove `pdfmake`, add `puppeteer-core`, `remark-rehype`, `rehype-stringify` |
+| [esbuild.config.js](esbuild.config.js) | Remove `copyFonts()` + `exportPdfConfig` giữ nhưng không cần copy font |
+| [src/utils/export-pdf.ts](src/utils/export-pdf.ts) | Rewrite hoàn toàn (339 dòng → ~150 dòng) |
+| [src/utils/chromium-discovery.ts](src/utils/chromium-discovery.ts) | **Mới** — logic tìm Chromium executable |
+| [src/markdownEditorProvider.ts](src/markdownEditorProvider.ts) | Update call signature: `exportToPdf(mdast, uri)` |
+
+## Tasks
+
+### 1. Chromium Discovery strategy
+
+Phải hỗ trợ cross-platform, có fallback. Đề xuất chuỗi thử:
+
+1. **VS Code Electron executable** (`process.execPath`):
+   - Pros: Luôn có, không đòi user cài thêm.
+   - Cons: Electron version của VS Code có thể chạy puppeteer không? Cần verify. Một số puppeteer API (như `connect` qua CDP) có thể không hoạt động với Electron renderer vì khác mode.
+   - Verify sớm: `process.execPath` trỏ đến `Electron.app/Contents/MacOS/Electron` trên macOS.
+2. **System Chrome/Chromium/Edge** common paths:
+   - macOS: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`, `/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge`
+   - Windows: `C:\Program Files\Google\Chrome\Application\chrome.exe`, `C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`, Edge equivalents
+   - Linux: `/usr/bin/google-chrome`, `/usr/bin/chromium-browser`, `/usr/bin/chromium`, `/snap/bin/chromium`
+3. **Environment variable** `PUPPETEER_EXECUTABLE_PATH`
+4. **Error UX**: Nếu không tìm thấy, hiện dialog: "PDF export cần Chrome/Chromium. Cài đặt rồi thử lại, hoặc set `tuiMarkdown.chromiumPath` trong settings."
+
+### 2. `src/utils/chromium-discovery.ts`
+- [ ] Function `findChromiumExecutable(): Promise<string | null>`.
+- [ ] Check env var trước, rồi system paths theo OS.
+- [ ] Cache kết quả (module-level variable) để tránh check lại mỗi lần export.
+- [ ] Optional: thêm setting `tuiMarkdown.chromiumPath` (string, default empty) để user override.
+
+### 3. Cập nhật `package.json`
+- [ ] `npm uninstall pdfmake`
+- [ ] `npm install puppeteer-core@^24 remark-rehype@^11 rehype-stringify@^10 rehype-highlight@^7` (cho syntax highlight)
+- [ ] Optional: `rehype-sanitize` nếu cần sanitize HTML từ user markdown (tránh XSS khi render trong Chromium).
+
+### 4. Cập nhật `esbuild.config.js`
+- [ ] Xoá hàm `copyFonts()` và call tương ứng.
+- [ ] Thêm `puppeteer-core` vào `external` list (không bundle, require at runtime):
+  ```js
+  const exportPdfConfig = {
+    // ...
+    external: ['vscode', 'puppeteer-core'],
+  };
+  ```
+- [ ] Bundle size `out/export-pdf.js` sẽ nhỏ hơn (< 200KB), nhưng user cần `node_modules/puppeteer-core` có mặt trong VSIX.
+- [ ] Verify VSIX include `node_modules/puppeteer-core`: update `.vscodeignore` nếu cần.
+
+### 5. Rewrite `src/utils/export-pdf.ts`
+- [ ] Pipeline:
+  ```ts
+  import { unified } from "unified";
+  import remarkRehype from "remark-rehype";
+  import rehypeStringify from "rehype-stringify";
+  import rehypeHighlight from "rehype-highlight";
+  import type { Root } from "mdast";
+  import { findChromiumExecutable } from "./chromium-discovery";
+
+  async function mdastToHtml(mdast: Root): Promise<string> {
+    const file = await unified()
+      .use(remarkRehype, { allowDangerousHtml: true })  // mermaid SVG/HTML
+      .use(rehypeHighlight)
+      .use(rehypeStringify, { allowDangerousHtml: true })
+      .run(mdast);
+    return String(file);
+  }
+
+  function buildHtmlDocument(bodyHtml: string, title: string): string {
+    return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #333; line-height: 1.625; }
+  h1, h2, h3, h4, h5, h6 { text-wrap: balance; margin-top: 32px; margin-bottom: 12px; }
+  h1 { font-size: 32px; } h2 { font-size: 24px; } h3 { font-size: 20px; }
+  code { background: #f5f5f5; padding: 2px 6px; border-radius: 3px; font-family: Cascadia Code, Fira Code, monospace; }
+  pre { background: #f5f5f5; padding: 12px; border-radius: 6px; overflow-x: auto; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; }
+  th, td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
+  th { background: #f0f0f0; font-weight: 600; }
+  blockquote { border-left: 4px solid #ccc; margin: 16px 0; padding: 4px 16px; color: #555; }
+  img { max-width: 100%; height: auto; }
+  a { color: #2563eb; text-decoration: underline; }
+  hr { border: none; border-top: 1.5px dashed #ccc; margin: 24px 0; }
+</style>
+</head>
+<body>${bodyHtml}</body>
+</html>`;
+  }
+
+  export async function exportToPdf(mdast: Root, documentUri: vscode.Uri) {
+    const docName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
+    const saveUri = await vscode.window.showSaveDialog({ /* ... */ });
+    if (!saveUri) return;
+
+    const chromiumPath = await findChromiumExecutable();
+    if (!chromiumPath) {
+      vscode.window.showErrorMessage(
+        "PDF export cần Chrome/Chromium/Edge đã cài trên máy. Hoặc set tuiMarkdown.chromiumPath trong settings."
+      );
+      return;
+    }
+
+    await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: "Exporting PDF…" },
+      async () => {
+        const puppeteer = require("puppeteer-core");
+        const browser = await puppeteer.launch({
+          executablePath: chromiumPath,
+          headless: true,
+          args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        });
+        try {
+          const page = await browser.newPage();
+          const html = await mdastToHtml(mdast);
+          const fullHtml = buildHtmlDocument(html, docName);
+          await page.setContent(fullHtml, { waitUntil: "networkidle0" });
+          const pdfBuffer = await page.pdf({
+            format: "A4",
+            printBackground: true,
+            margin: { top: "20mm", right: "15mm", bottom: "20mm", left: "15mm" },
+          });
+          await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
+        } finally {
+          await browser.close();
+        }
+      }
+    );
+    // ... show notification Open File / Open Folder
+  }
+  ```
+- [ ] `escapeHtml` helper nhỏ.
+- [ ] Xoá toàn bộ `markdownToPdfContent`, `parseInline`, `parseTable`, font loading code.
+
+### 6. `.vscodeignore` check
+- [ ] Verify `node_modules/puppeteer-core` không bị ignore khỏi VSIX.
+- [ ] Tuy nhiên `puppeteer-core` KHÔNG bundle Chromium binary, nên VSIX size không quá lớn. Check: `node_modules/puppeteer-core` size sau install (~10MB unpacked).
+
+### 7. CSS theme matching (optional enhancement)
+- [ ] Nâng cao: pass theme hiện tại của editor vào `buildHtmlDocument` để PDF match màu sắc.
+- [ ] Defer nếu effort lớn.
+
+### 8. Test matrix
+- [ ] Heading, list (nested + task list), table (multi-line cell, escape pipe)
+- [ ] Code block với nhiều ngôn ngữ (JavaScript, Python, Bash)
+- [ ] Syntax highlight có màu
+- [ ] Mermaid base64 inline render đúng
+- [ ] Frontmatter đã strip (từ Stage 3)
+- [ ] File lớn (~500KB markdown + 10 mermaid)
+- [ ] Cross-platform: test trên macOS (chắc chắn), nếu có máy Windows/Linux verify luôn
+
+## Verify
+
+```bash
+npm run lint
+npm run build
+ls -lh out/export-pdf.js  # phải < 200KB (xoá parser + font + pdfmake)
+du -sh node_modules/puppeteer-core  # ghi lại size
+npm run package  # tạo VSIX, check size
+```
+
+## Rollback
+
+Stage này commit riêng. Nếu sai: `git revert <commit>` và `npm install` restore pdfmake.
+
+## Risks
+
+### High
+- **Electron của VS Code có thể không chạy được puppeteer** với `process.execPath`. Phải PoC verify sớm. Nếu fail → rely on system Chrome (user phải cài).
+- **VSIX size tăng**: puppeteer-core node_modules ~10MB. Extension hiện tại bao nhiêu? Check `npm run package` output size.
+
+### Medium
+- **Security**: `page.setContent` + `allowDangerousHtml` có thể XSS nếu user markdown chứa `<script>`. Chromium headless có `--no-sandbox` sẽ chạy script. Mitigations:
+  - `rehype-sanitize` trước khi stringify (loại script, event handler). Nhưng có thể làm mất mermaid SVG foreignObject.
+  - Hoặc: whitelist HTML tags cho phép (svg, foreignObject, div, span, br) và loại script.
+  - Chạy Chromium với `--disable-javascript` vì không cần JS để render markdown tĩnh.
+- **Cold start ~1s**: user cảm giác chậm. Show progress notification đủ.
+- **Mermaid SVG với foreignObject HTML**: Chromium render tốt hơn pdfkit, đây là lợi thế.
+
+### Low
+- **Font rendering khác nhau giữa user OS**: PDF dùng font system, khác nhau macOS/Windows/Linux. Acceptable.
+
+## Done criteria
+
+- [ ] PDF export cross-platform trên ít nhất macOS
+- [ ] Bundle VSIX size tăng không quá 15MB (từ current size)
+- [ ] Test matrix pass
+- [ ] Parser tự viết 339 dòng đã xoá hết
+- [ ] pdfmake + Roboto font đã gỡ khỏi package.json và `out/`
+- [ ] Commit message: `refactor(export): rewrite PDF với puppeteer-core, bỏ pdfmake`
+
+## Follow-up (out of scope)
+
+- Theme-aware PDF (PDF dùng CSS theme user đang chọn trong editor)
+- Page number, header/footer tuỳ chỉnh
+- Cover page với frontmatter metadata
+- Print preview trong webview trước khi export

--- a/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
@@ -194,7 +194,7 @@ Phải hỗ trợ cross-platform, có fallback. Đề xuất chuỗi thử:
 ```bash
 npm run lint
 npm run build
-ls -lh out/export-pdf.js  # phải < 200KB (xoá parser + font + pdfmake)
+ls -lh out/export-pdf.js  # phải < 3MB (puppeteer-core bundled inline)
 du -sh node_modules/puppeteer-core  # ghi lại size
 npm run package  # tạo VSIX, check size
 ```

--- a/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
+++ b/_bmad-output/implementation-artifacts/plan-stage-4-puppeteer-pdf.md
@@ -1,6 +1,6 @@
 # Plan Stage 4 — PDF rewrite với `puppeteer-core`
 
-**Status**: ready
+**Status**: done (2026-04-22)
 **Estimated effort**: 1-1.5 ngày (8-12 giờ)
 **Risk**: Cao (Chromium discovery cross-platform, bundle footprint)
 **Dependencies**: **PHẢI làm sau Stage 3** (cần MDAST pipeline sẵn sàng)
@@ -69,16 +69,19 @@ Phải hỗ trợ cross-platform, có fallback. Đề xuất chuỗi thử:
 - [ ] Optional: `rehype-sanitize` nếu cần sanitize HTML từ user markdown (tránh XSS khi render trong Chromium).
 
 ### 4. Cập nhật `esbuild.config.js`
-- [ ] Xoá hàm `copyFonts()` và call tương ứng.
-- [ ] Thêm `puppeteer-core` vào `external` list (không bundle, require at runtime):
+- [x] Xoá hàm `copyFonts()` và call tương ứng.
+- [x] `puppeteer-core` được bundle INLINE vào `out/export-pdf.js` (tree-shake qua esbuild). Chỉ `vscode` là external.
   ```js
   const exportPdfConfig = {
     // ...
-    external: ['vscode', 'puppeteer-core'],
+    external: ['vscode'],
   };
   ```
-- [ ] Bundle size `out/export-pdf.js` sẽ nhỏ hơn (< 200KB), nhưng user cần `node_modules/puppeteer-core` có mặt trong VSIX.
-- [ ] Verify VSIX include `node_modules/puppeteer-core`: update `.vscodeignore` nếu cần.
+- [x] Bundle size thực tế `out/export-pdf.js` ~2.5MB (inline puppeteer-core). Quyết định giữ inline để:
+  1. `.vscodeignore` có thể giữ `node_modules/**` catch-all → VSIX nhỏ gọn, không lo sót dep.
+  2. Extension lazy-load qua `require()` tại runtime chỉ khi user bấm Export PDF, cold path.
+  3. Tránh phụ thuộc vào đường dẫn `node_modules` tại runtime cross-platform.
+- [x] `.vscodeignore` giữ nguyên pattern `node_modules/**`.
 
 ### 5. Rewrite `src/utils/export-pdf.ts`
 - [ ] Pipeline:
@@ -219,11 +222,12 @@ Stage này commit riêng. Nếu sai: `git revert <commit>` và `npm install` res
 
 ## Done criteria
 
-- [ ] PDF export cross-platform trên ít nhất macOS
-- [ ] Bundle VSIX size tăng không quá 15MB (từ current size)
-- [ ] Test matrix pass
-- [ ] Parser tự viết 339 dòng đã xoá hết
-- [ ] pdfmake + Roboto font đã gỡ khỏi package.json và `out/`
+- [x] PDF export cross-platform trên ít nhất macOS
+- [x] Bundle VSIX size tăng không quá 15MB (từ current size) — inline `out/export-pdf.js` ~2.5MB, VSIX vẫn dưới ngưỡng.
+- [x] Test matrix pass (manual verification)
+- [x] Parser tự viết 339 dòng đã xoá hết
+- [x] pdfmake + Roboto font đã gỡ khỏi package.json và `out/`
+- [x] `out/export-pdf.js` size < 3MB (revised từ <200KB do quyết định bundle inline thay vì external — xem Task 4)
 - [ ] Commit message: `refactor(export): rewrite PDF với puppeteer-core, bỏ pdfmake`
 
 ## Follow-up (out of scope)

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,5 +1,4 @@
 const esbuild = require('esbuild');
-const path = require('path');
 const fs = require('fs');
 
 const isDev = process.argv.includes('--dev');
@@ -86,22 +85,9 @@ function ensureOutDir() {
   }
 }
 
-// Copy pdfmake font files to output directory for runtime use
-function copyFonts() {
-  const pdfmakeDir = path.join(__dirname, 'node_modules', 'pdfmake', 'build', 'fonts', 'Roboto');
-  const outFontsDir = path.join(__dirname, 'out', 'fonts');
-  if (!fs.existsSync(outFontsDir)) fs.mkdirSync(outFontsDir, { recursive: true });
-  for (const file of fs.readdirSync(pdfmakeDir)) {
-    if (file.endsWith('.ttf')) {
-      fs.copyFileSync(path.join(pdfmakeDir, file), path.join(outFontsDir, file));
-    }
-  }
-}
-
 async function build() {
   console.log(`Building (${isProduction ? 'production' : 'development'})...`);
   ensureOutDir();
-  copyFonts();
 
   if (isWatch) {
     const extCtx = await esbuild.context(extensionConfig);

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -18,6 +18,20 @@ const extensionConfig = {
   treeShaking: true,
 };
 
+// Separate bundle for the shared MDAST pipeline (lazy-loaded on demand).
+// Holds unified + remark-* so extension.js stays small.
+const markdownAstConfig = {
+  entryPoints: ['src/utils/markdown-ast.ts'],
+  bundle: true,
+  outfile: 'out/markdown-ast.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  sourcemap: !isProduction,
+  minify: isProduction,
+  treeShaking: true,
+};
+
 // Separate bundle for export-docx (lazy-loaded on demand)
 // Keeps the main extension.js small; this file is only loaded when user exports.
 const exportDocxConfig = {
@@ -91,13 +105,21 @@ async function build() {
 
   if (isWatch) {
     const extCtx = await esbuild.context(extensionConfig);
+    const markdownAstCtx = await esbuild.context(markdownAstConfig);
     const exportDocxCtx = await esbuild.context(exportDocxConfig);
     const exportPdfCtx = await esbuild.context(exportPdfConfig);
     const webCtx = await esbuild.context(webviewConfig);
-    await Promise.all([extCtx.watch(), exportDocxCtx.watch(), exportPdfCtx.watch(), webCtx.watch()]);
+    await Promise.all([
+      extCtx.watch(),
+      markdownAstCtx.watch(),
+      exportDocxCtx.watch(),
+      exportPdfCtx.watch(),
+      webCtx.watch(),
+    ]);
     console.log('Watching for changes...');
   } else {
     await esbuild.build(extensionConfig);
+    await esbuild.build(markdownAstConfig);
     await esbuild.build(exportDocxConfig);
     await esbuild.build(exportPdfConfig);
     await esbuild.build(webviewConfig);

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -18,6 +18,33 @@ const extensionConfig = {
   treeShaking: true,
 };
 
+// Separate bundle for export-docx (lazy-loaded on demand)
+// Keeps the main extension.js small; this file is only loaded when user exports.
+const exportDocxConfig = {
+  entryPoints: ['src/utils/export-docx.ts'],
+  bundle: true,
+  outfile: 'out/export-docx.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  sourcemap: !isProduction,
+  minify: isProduction,
+  treeShaking: true,
+};
+
+// Separate bundle for export-pdf (lazy-loaded on demand)
+const exportPdfConfig = {
+  entryPoints: ['src/utils/export-pdf.ts'],
+  bundle: true,
+  outfile: 'out/export-pdf.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  sourcemap: !isProduction,
+  minify: isProduction,
+  treeShaking: true,
+};
+
 const webviewConfig = {
   entryPoints: ['src/webview/main.ts'],
   bundle: true,
@@ -45,17 +72,34 @@ function ensureOutDir() {
   }
 }
 
+// Copy pdfmake font files to output directory for runtime use
+function copyFonts() {
+  const pdfmakeDir = path.join(__dirname, 'node_modules', 'pdfmake', 'build', 'fonts', 'Roboto');
+  const outFontsDir = path.join(__dirname, 'out', 'fonts');
+  if (!fs.existsSync(outFontsDir)) fs.mkdirSync(outFontsDir, { recursive: true });
+  for (const file of fs.readdirSync(pdfmakeDir)) {
+    if (file.endsWith('.ttf')) {
+      fs.copyFileSync(path.join(pdfmakeDir, file), path.join(outFontsDir, file));
+    }
+  }
+}
+
 async function build() {
   console.log(`Building (${isProduction ? 'production' : 'development'})...`);
   ensureOutDir();
+  copyFonts();
 
   if (isWatch) {
     const extCtx = await esbuild.context(extensionConfig);
+    const exportDocxCtx = await esbuild.context(exportDocxConfig);
+    const exportPdfCtx = await esbuild.context(exportPdfConfig);
     const webCtx = await esbuild.context(webviewConfig);
-    await Promise.all([extCtx.watch(), webCtx.watch()]);
+    await Promise.all([extCtx.watch(), exportDocxCtx.watch(), exportPdfCtx.watch(), webCtx.watch()]);
     console.log('Watching for changes...');
   } else {
     await esbuild.build(extensionConfig);
+    await esbuild.build(exportDocxConfig);
+    await esbuild.build(exportPdfConfig);
     await esbuild.build(webviewConfig);
     console.log(`Build complete (${isProduction ? 'production' : 'development'})`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "tui-milkdown-vscode",
-  "version": "2.8.3",
+  "version": "2.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tui-milkdown-vscode",
-      "version": "2.8.3",
+      "version": "2.8.5",
       "license": "MIT",
       "dependencies": {
+        "@m2d/md2docx": "^0.0.1",
+        "@mermaid-js/layout-elk": "^0.2.1",
         "@tiptap/core": "^3.19.0",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
         "@tiptap/extension-highlight": "^3.19.0",
@@ -24,6 +26,7 @@
         "js-yaml": "^4.1.1",
         "lowlight": "^3.3.0",
         "mermaid": "^11.12.2",
+        "pdfmake": "^0.3.7",
         "prosemirror-search": "^1.1.0"
       },
       "devDependencies": {
@@ -515,6 +518,264 @@
         "mlly": "^1.8.0"
       }
     },
+    "node_modules/@m2d/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@m2d/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-lS9z0MLE6bn1Bh0AyjSRXsXdwXSr2NUHbRcuNk+36y7naBEWXRRTSt4JfuuInbhUtEqEMNCbEI6VicOZF1nOLA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tiny-md"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/mdast": "^0.2.4"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/emoji": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@m2d/emoji/-/emoji-0.1.3.tgz",
+      "integrity": "sha512-oskui4ZrK89Q2F/9ptrbquGpXEJT44VZaEE/nyBTaolcee0pOjF+YBgj9pmo7NwHsoRcSoZ02PoB/ziWkmq28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.3.4"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/html": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@m2d/html/-/html-1.1.11.tgz",
+      "integrity": "sha512-BZac1eahlaaWeWbhNm4IsYAlNuGkXsaDKCgKf976FyN2f9hHCPGS5G7dnR4TP3HVHJa61dYSLP5CHH3s6xjazQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.7.0"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/image": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@m2d/image/-/image-1.4.1.tgz",
+      "integrity": "sha512-kW5bJJoSJP/gkFOvXE4Lm4cQk/NUPeMQs7C8eltSEYXcqwaMmbmXDm/PEMbU3K3sPNw+jZMBtrgrhbgOTiX6pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.7.0",
+        "@svg-fns/io": "^1.0.0",
+        "@svg-fns/svg2img": "^0.0.0"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/list": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@m2d/list/-/list-0.0.9.tgz",
+      "integrity": "sha512-wPSmeNq9VwQLgaSUxegmhpJIMlLrFfEG5WzMGui4tf9FcvtntwKJUM6y8cd9OXZoWbfJjkl4/ubTAXE5BYx/tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.7.0"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/math": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@m2d/math/-/math-0.0.6.tgz",
+      "integrity": "sha512-KEmCT6UXUiBZVt7Rp6XDq4nPjrs1LM7J3bJA8/MphyEaIRL8mYyUC/3pKVqzNd4Pf9+/DwarWdON1VLwA6wKsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.3.4",
+        "latex-math": "^0.0.2"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0",
+        "remark-math": "^6.0.0"
+      }
+    },
+    "node_modules/@m2d/md2docx": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@m2d/md2docx/-/md2docx-0.0.1.tgz",
+      "integrity": "sha512-kQ2Q9Zskmf0ChSXeAWTn7+MyCVwtcWLulY5LhOLhd6SMD3eisDMB8/Dk5LSSgQOO46m24veHwd6Iy4sG0jZspw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/remark-docx": "^1.2.2",
+        "docx": "^9.5.1",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@m2d/mdast": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@m2d/mdast/-/mdast-0.2.4.tgz",
+      "integrity": "sha512-OksRST8MeVMzYxeFC5Ls/FS1sw9w/4cwsvagTQcFeMsmZ1IQt4gp+2uVGfbDjX0jIsDvlhQWZRZdqZp0C/9qSw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/mermaid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@m2d/mermaid/-/mermaid-1.2.2.tgz",
+      "integrity": "sha512-UEz1BSJOp6i23UzME7yh5si/ndiMvuBvt3QLjOPj8ZGFfU6hf0/GdDi3SWl9pc9h0jvhzA/kXq03Tc1b2lKxnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.4.1",
+        "mermaid": "^11.6.0"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@m2d/remark-docx": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@m2d/remark-docx/-/remark-docx-1.2.2.tgz",
+      "integrity": "sha512-sKItySqayVnxolCdVbEJUkN83LAaUPtU56VZkrmG/DhxxuKWXmIvjpWYCqPSSnDtDC9waWWOQhfOxdKWn3UB4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "docx": "^9.5.1",
+        "mdast2docx": "1.6.1"
+      }
+    },
+    "node_modules/@m2d/table": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@m2d/table/-/table-0.1.1.tgz",
+      "integrity": "sha512-VcrZIt1lRo1TetMOCMSGoin0IVrBMBkX1SF0NSUbPM6smUfLm5nsO7oFnXfre7VZMnD2rM+tkzm+lHCZdON6Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.7.0"
+      },
+      "peerDependencies": {
+        "docx": "^9.3.0"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.1.tgz",
+      "integrity": "sha512-MX9jwhMyd5zDcFsYcl3duDUkKhjVRUCGEQrdCeNV5hCIR6+3FuDDbRbFmvVbAu15K1+juzsYGG+K8MDvCY1Amg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
     "node_modules/@mermaid-js/parser": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
@@ -524,11 +785,92 @@
         "langium": "3.3.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
+    },
+    "node_modules/@svg-fns/io": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@svg-fns/io/-/io-1.0.1.tgz",
+      "integrity": "sha512-QcrGrP+JO9zkmFwBaAOLstA4qMzfM+RDoQrYm6JnQX/WhB56Uj5+goC+IhzAf7d0xbW7EbhBrYarr1dvP8D6hA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/svg-fns"
+        },
+        {
+          "type": "github",
+          "url": "https:/github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@xmldom/xmldom": "^0.8.11"
+      },
+      "peerDependenciesMeta": {
+        "@xmldom/xmldom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@svg-fns/svg2img": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@svg-fns/svg2img/-/svg2img-0.0.0.tgz",
+      "integrity": "sha512-9hj1BlZGabIhd8l93qge6rA+B0xb0+EDGWVA/1mHQ93Y+85aX4XQkuEptCqKogI0/BNW0Rzcedjw7idRknyy1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/svg-fns"
+        },
+        {
+          "type": "github",
+          "url": "https:/github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "sharp": "^0.34.4"
+      },
+      "peerDependenciesMeta": {
+        "sharp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tiptap/core": {
       "version": "3.19.0",
@@ -1243,6 +1585,15 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -1265,6 +1616,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -1281,20 +1638,34 @@
         "@types/mdurl": "^2"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -1335,6 +1706,83 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/brotli/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chevrotain": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
@@ -1367,6 +1815,15 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -1380,6 +1837,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cose-base": {
@@ -1902,6 +2365,36 @@
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -1933,6 +2426,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
@@ -1941,6 +2457,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "license": "EPL-2.0"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2005,11 +2527,71 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
     },
     "node_modules/highlight.js": {
       "version": "11.11.1",
@@ -2032,6 +2614,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2040,6 +2634,30 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -2051,6 +2669,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/katex": {
@@ -2099,11 +2729,49 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/latex-math": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/latex-math/-/latex-math-0.0.2.tgz",
+      "integrity": "sha512-tJbCMbMhkeocxkx5H9pGISfay6pctCmcZW7yajYe3KrytIxIChqlAw1cvp9VlobNZC27LeV0PoChM96xa0ATew==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tiny-md"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "unified": "^11.0.5"
+      }
+    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -2125,6 +2793,16 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/lowlight": {
       "version": "3.3.0",
@@ -2158,6 +2836,16 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
@@ -2168,6 +2856,283 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast2docx": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mdast2docx/-/mdast2docx-1.6.1.tgz",
+      "integrity": "sha512-7V81UXEtj6qyfLKS7Fjqy7Hs+tg9hMSRlATvPLRNW/u9K8NkH0Am/tJBk1KQwXuczvT3urubUqmkEiPitUEvhg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/md2docx"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mayank1513"
+        }
+      ],
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@m2d/core": "^1.7.1",
+        "@m2d/emoji": "^0.1.3",
+        "@m2d/html": "^1.1.11",
+        "@m2d/image": "^1.4.1",
+        "@m2d/list": "^0.0.9",
+        "@m2d/math": "^0.0.6",
+        "@m2d/mermaid": "^1.2.2",
+        "@m2d/table": "^0.1.1",
+        "docx": "^9.5.1"
       }
     },
     "node_modules/mdurl": {
@@ -2216,6 +3181,610 @@
         "node": ">= 20"
       }
     },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -2226,6 +3795,30 @@
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/orderedmap": {
@@ -2240,6 +3833,12 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -2252,6 +3851,34 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.7.tgz",
+      "integrity": "sha512-SwTFcaH3kCJBlPFWi/YB34zRg6lpCxq90tkZ9GxfSi9/v4Tk96cv4IvOstA+CC40rdW1OzQIuNhD2DLD1RDVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.18.0",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -2261,6 +3888,14 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -2278,6 +3913,12 @@
         "path-data-parser": "0.1.0",
         "points-on-curve": "0.2.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -2494,6 +4135,108 @@
         "node": ">=6"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -2524,16 +4267,52 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -2545,6 +4324,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -2553,6 +4342,12 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2581,10 +4376,149 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-properties/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -2598,6 +4532,34 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -2654,6 +4616,46 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "unified": "^11.0.5"
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "2.8.5",
       "license": "MIT",
       "dependencies": {
-        "@m2d/md2docx": "^0.0.1",
+        "@m2d/html": "^1.1.11",
+        "@m2d/image": "^1.4.1",
+        "@m2d/list": "^0.0.9",
+        "@m2d/table": "^0.1.1",
         "@mermaid-js/layout-elk": "^0.2.1",
         "@tiptap/core": "^3.19.0",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
@@ -23,11 +26,17 @@
         "@tiptap/markdown": "^3.19.0",
         "@tiptap/pm": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
+        "image-size": "^2.0.2",
         "js-yaml": "^4.1.1",
         "lowlight": "^3.3.0",
+        "mdast2docx": "^1.6.1",
         "mermaid": "^11.12.2",
         "pdfmake": "^0.3.7",
-        "prosemirror-search": "^1.1.0"
+        "prosemirror-search": "^1.1.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -654,31 +663,6 @@
         "remark-math": "^6.0.0"
       }
     },
-    "node_modules/@m2d/md2docx": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@m2d/md2docx/-/md2docx-0.0.1.tgz",
-      "integrity": "sha512-kQ2Q9Zskmf0ChSXeAWTn7+MyCVwtcWLulY5LhOLhd6SMD3eisDMB8/Dk5LSSgQOO46m24veHwd6Iy4sG0jZspw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/md2docx"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mayank1513"
-        }
-      ],
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@m2d/remark-docx": "^1.2.2",
-        "docx": "^9.5.1",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-math": "^6.0.0",
-        "remark-parse": "^11.0.0",
-        "unified": "^11.0.5"
-      }
-    },
     "node_modules/@m2d/mdast": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@m2d/mdast/-/mdast-0.2.4.tgz",
@@ -719,26 +703,6 @@
       },
       "peerDependencies": {
         "docx": "^9.3.0"
-      }
-    },
-    "node_modules/@m2d/remark-docx": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@m2d/remark-docx/-/remark-docx-1.2.2.tgz",
-      "integrity": "sha512-sKItySqayVnxolCdVbEJUkN83LAaUPtU56VZkrmG/DhxxuKWXmIvjpWYCqPSSnDtDC9waWWOQhfOxdKWn3UB4A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/md2docx"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mayank1513"
-        }
-      ],
-      "license": "MPL-2.0",
-      "dependencies": {
-        "docx": "^9.5.1",
-        "mdast2docx": "1.6.1"
       }
     },
     "node_modules/@m2d/table": {
@@ -1620,7 +1584,8 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -2614,6 +2579,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -3046,6 +3023,7 @@
       "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
       "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -3392,6 +3370,7 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
       "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/katex": "^0.16.0",
         "devlop": "^1.0.0",
@@ -4189,6 +4168,7 @@
       "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
       "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-math": "^3.0.0",
@@ -4464,6 +4444,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
       "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,14 @@
         "lowlight": "^3.3.0",
         "mdast2docx": "^1.6.1",
         "mermaid": "^11.12.2",
-        "pdfmake": "^0.3.7",
         "prosemirror-search": "^1.1.0",
+        "puppeteer-core": "^24.42.0",
+        "rehype-highlight": "^7.0.2",
+        "rehype-stringify": "^10.0.1",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
+        "remark-rehype": "^11.1.2",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0"
       },
@@ -751,28 +753,25 @@
         "langium": "3.3.1"
       }
     },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remirror/core-constants": {
@@ -827,15 +826,6 @@
         "sharp": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tiptap/core": {
@@ -1298,6 +1288,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -1655,6 +1651,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1667,11 +1679,70 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -1683,51 +1754,113 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=10.0.0"
       }
     },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.1.2"
-      }
-    },
-    "node_modules/brotli/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "~1.0.5"
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ccount": {
@@ -1744,6 +1877,26 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1782,13 +1935,59 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2326,6 +2525,15 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -2362,6 +2570,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -2393,11 +2615,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dfa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-      "license": "MIT"
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1595872",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/docx": {
       "version": "9.6.1",
@@ -2430,6 +2652,21 @@
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "license": "EPL-2.0"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2482,6 +2719,15 @@
         "@esbuild/win32-x64": "0.20.2"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2494,16 +2740,97 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fault": {
@@ -2519,21 +2846,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/fontkit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "license": "MIT",
       "dependencies": {
-        "@swc/helpers": "^0.5.12",
-        "brotli": "^1.3.2",
-        "clone": "^2.1.2",
-        "dfa": "^1.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "restructure": "^3.0.0",
-        "tiny-inflate": "^1.0.3",
-        "unicode-properties": "^1.4.0",
-        "unicode-trie": "^2.0.0"
+        "pend": "~1.2.0"
       }
     },
     "node_modules/format": {
@@ -2542,6 +2861,44 @@
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/hachure-fill": {
@@ -2560,6 +2917,71 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -2567,6 +2989,42 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2614,6 +3072,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -2630,12 +3106,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/js-md5": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
-      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2742,16 +3212,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "node_modules/linebreak": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
-      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "0.0.8",
-        "unicode-trie": "^2.0.0"
-      }
-    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -2796,6 +3256,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/markdown-it": {
@@ -3048,6 +3517,27 @@
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3766,6 +4256,12 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -3802,11 +4298,61 @@
         "node": "^18 || >=20"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
@@ -3832,33 +4378,11 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
-    "node_modules/pdfkit": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
-      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/hashes": "^1.6.0",
-        "fontkit": "^2.0.4",
-        "js-md5": "^0.8.3",
-        "linebreak": "^1.1.0",
-        "png-js": "^1.0.0"
-      }
-    },
-    "node_modules/pdfmake": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.7.tgz",
-      "integrity": "sha512-SwTFcaH3kCJBlPFWi/YB34zRg6lpCxq90tkZ9GxfSi9/v4Tk96cv4IvOstA+CC40rdW1OzQIuNhD2DLD1RDVgA==",
-      "license": "MIT",
-      "dependencies": {
-        "linebreak": "^1.1.0",
-        "pdfkit": "^0.18.0",
-        "xmldoc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
@@ -3869,14 +4393,6 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/png-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
-      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
-      "dependencies": {
-        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -3900,6 +4416,25 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -4107,6 +4642,41 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -4114,6 +4684,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.42.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
+      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1595872",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/readable-stream": {
@@ -4129,6 +4717,38 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-frontmatter": {
@@ -4198,6 +4818,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
@@ -4213,11 +4850,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/restructure": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-      "license": "MIT"
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
@@ -4270,11 +4910,92 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -4285,17 +5006,95 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT"
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -4304,6 +5103,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/trough": {
@@ -4330,6 +5139,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -4363,52 +5178,6 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
-    "node_modules/unicode-properties": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-properties/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
-    "node_modules/unicode-trie/node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT"
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -4428,10 +5197,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -4600,6 +5396,56 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -4618,16 +5464,59 @@
         "xml-js": "bin/cli.js"
       }
     },
-    "node_modules/xmldoc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
-      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
-        "sax": "^1.4.3"
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",
@@ -108,6 +108,11 @@
           "type": "boolean",
           "default": false,
           "description": "Auto-hide toolbar when typing (show on hover)"
+        },
+        "tuiMarkdown.chromiumPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to a Chrome/Chromium/Edge/Brave executable used for PDF export. Leave empty to auto-detect."
         }
       }
     },
@@ -170,12 +175,14 @@
     "lowlight": "^3.3.0",
     "mdast2docx": "^1.6.1",
     "mermaid": "^11.12.2",
-    "pdfmake": "^0.3.7",
     "prosemirror-search": "^1.1.0",
+    "puppeteer-core": "^24.42.0",
+    "rehype-highlight": "^7.0.2",
+    "rehype-stringify": "^10.0.1",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
-    "remark-stringify": "^11.0.0",
+    "remark-rehype": "^11.1.2",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,12 @@
           "type": "string",
           "default": "",
           "description": "Absolute path to a Chrome/Chromium/Edge/Brave executable used for PDF export. Leave empty to auto-detect."
+        },
+        "tuiMarkdown.exportPageSize": {
+          "type": "string",
+          "enum": ["A4", "Letter"],
+          "default": "A4",
+          "description": "Page size for PDF and DOCX export"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -133,8 +133,8 @@
     ],
     "configurationDefaults": {
       "workbench.editorAssociations": {
-        "{git,gitlens}:/**/*.md": "default",
-        "{git,gitlens}:/**/*.markdown": "default"
+        "{git,gitlens,git-graph}:/**/*.md": "default",
+        "{git,gitlens,git-graph}:/**/*.markdown": "default"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -175,6 +175,8 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
-    "unified": "^11.0.5"
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -148,6 +148,8 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
+    "@m2d/md2docx": "^0.0.1",
+    "@mermaid-js/layout-elk": "^0.2.1",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-highlight": "^3.19.0",
@@ -163,6 +165,7 @@
     "js-yaml": "^4.1.1",
     "lowlight": "^3.3.0",
     "mermaid": "^11.12.2",
+    "pdfmake": "^0.3.7",
     "prosemirror-search": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -148,7 +148,10 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
-    "@m2d/md2docx": "^0.0.1",
+    "@m2d/html": "^1.1.11",
+    "@m2d/image": "^1.4.1",
+    "@m2d/list": "^0.0.9",
+    "@m2d/table": "^0.1.1",
     "@mermaid-js/layout-elk": "^0.2.1",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
@@ -162,10 +165,16 @@
     "@tiptap/markdown": "^3.19.0",
     "@tiptap/pm": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
+    "image-size": "^2.0.2",
     "js-yaml": "^4.1.1",
     "lowlight": "^3.3.0",
+    "mdast2docx": "^1.6.1",
     "mermaid": "^11.12.2",
     "pdfmake": "^0.3.7",
-    "prosemirror-search": "^1.1.0"
+    "prosemirror-search": "^1.1.0",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5"
   }
 }

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -936,6 +936,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             const mermaidImages = exportMsg.mermaidImages || [];
             const exportFormat = exportMsg.format || "docx";
             const fontFamily = exportMsg.fontFamily || "";
+            const configuredPageSize = vscode.workspace
+              .getConfiguration("tuiMarkdown")
+              .get<string>("exportPageSize", "A4");
+            const pageSize: "A4" | "Letter" =
+              configuredPageSize === "Letter" ? "Letter" : "A4";
 
             // Strip only the BOM. Frontmatter is handled by remark-frontmatter
             // inside parseMarkdownToMdast, so avoid a regex that could eat a
@@ -951,6 +956,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                   parseMarkdownToMdast,
                   replaceMermaidBlocks,
                   hashMermaidCode,
+                  countMermaidBlocks,
                 } = require(markdownAstPath);
 
                 const mdast = await parseMarkdownToMdast(normalized);
@@ -971,18 +977,27 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 }
 
                 const imageMap = new Map<string, string>(
-                  mermaidImages.map(({ code, base64 }) => [hashMermaidCode(code), base64]),
+                  mermaidImages.map(({ code, base64 }: { code: string; base64: string }) => [
+                    hashMermaidCode(code),
+                    base64,
+                  ]),
                 );
-                await replaceMermaidBlocks(mdast, imageMap);
+                const totalMermaid = countMermaidBlocks(mdast);
+                const replaced = await replaceMermaidBlocks(mdast, imageMap);
+                if (replaced < totalMermaid) {
+                  vscode.window.showWarningMessage(
+                    `${totalMermaid - replaced} of ${totalMermaid} Mermaid diagram(s) could not be embedded (still rendering or parse error). They will appear as code in the export.`,
+                  );
+                }
 
                 if (exportFormat === "pdf") {
                   const exportPdfPath = require("path").join(__dirname, "export-pdf.js");
                   const { exportToPdf: doExport } = require(exportPdfPath);
-                  await doExport(mdast, document.uri, fontFamily);
+                  await doExport(mdast, document.uri, fontFamily, pageSize);
                 } else {
                   const exportDocxPath = require("path").join(__dirname, "export-docx.js");
                   const { exportToDocx: doExport } = require(exportDocxPath);
-                  await doExport(mdast, document.uri, fontFamily);
+                  await doExport(mdast, document.uri, fontFamily, pageSize);
                 }
 
                 // Notify webview on success so the button can re-enable without

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -928,7 +928,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 reason: "busy",
               });
               vscode.window.showWarningMessage(
-                "Đang export, vui lòng đợi export hiện tại kết thúc.",
+                "Export in progress, please wait for the current export to finish.",
               );
               break;
             }
@@ -965,7 +965,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
                 if (!mdast?.children || mdast.children.length === 0) {
                   vscode.window.showWarningMessage(
-                    "Document trống, không có nội dung để export.",
+                    "Document is empty, nothing to export.",
                   );
                   return;
                 }
@@ -994,7 +994,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 }
               } catch (err) {
                 const errMsg = err instanceof Error ? err.message : String(err);
-                vscode.window.showErrorMessage(`Export thất bại: ${errMsg}`);
+                vscode.window.showErrorMessage(`Export failed: ${errMsg}`);
                 console.error("[Export]", err);
                 try {
                   webviewPanel.webview.postMessage({

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -244,6 +244,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
     let pendingEdit = false;
     let renameInProgress = false;
+    let exportInProgress = false;
     let updateDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     const disposables: vscode.Disposable[] = [];
 
@@ -917,14 +918,32 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               fontFamily?: string;
               mermaidImages?: { code: string; base64: string }[];
             };
+
+            // Reject duplicate export requests so two save dialogs / two
+            // Chromium instances cannot race to the same output path.
+            if (exportInProgress) {
+              webviewPanel.webview.postMessage({
+                type: "exportDone",
+                success: false,
+                reason: "busy",
+              });
+              vscode.window.showWarningMessage(
+                "Đang export, vui lòng đợi export hiện tại kết thúc.",
+              );
+              break;
+            }
+
             const mermaidImages = exportMsg.mermaidImages || [];
             const exportFormat = exportMsg.format || "docx";
             const fontFamily = exportMsg.fontFamily || "";
 
+            // Strip only the BOM. Frontmatter is handled by remark-frontmatter
+            // inside parseMarkdownToMdast, so avoid a regex that could eat a
+            // legitimate `---` horizontal rule at the top of the document.
             const rawText = document.getText();
-            const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;
-            const bodyMarkdown = rawText.replace(frontmatterRegex, "");
+            const normalized = rawText.replace(/^﻿/, "");
 
+            exportInProgress = true;
             (async () => {
               try {
                 const markdownAstPath = require("path").join(__dirname, "markdown-ast.js");
@@ -932,10 +951,25 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                   parseMarkdownToMdast,
                   replaceMermaidBlocks,
                   hashMermaidCode,
-                  mdastToMarkdown,
                 } = require(markdownAstPath);
 
-                const mdast = await parseMarkdownToMdast(bodyMarkdown);
+                const mdast = await parseMarkdownToMdast(normalized);
+
+                // Drop the frontmatter node so it is not rendered as content.
+                if (
+                  mdast?.children?.[0] &&
+                  (mdast.children[0].type === "yaml" || mdast.children[0].type === "toml")
+                ) {
+                  mdast.children.shift();
+                }
+
+                if (!mdast?.children || mdast.children.length === 0) {
+                  vscode.window.showWarningMessage(
+                    "Document trống, không có nội dung để export.",
+                  );
+                  return;
+                }
+
                 const imageMap = new Map<string, string>(
                   mermaidImages.map(({ code, base64 }) => [hashMermaidCode(code), base64]),
                 );
@@ -944,17 +978,35 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 if (exportFormat === "pdf") {
                   const exportPdfPath = require("path").join(__dirname, "export-pdf.js");
                   const { exportToPdf: doExport } = require(exportPdfPath);
-                  const bridgedMarkdown = await mdastToMarkdown(mdast);
-                  await doExport(bridgedMarkdown, document.uri, fontFamily);
+                  await doExport(mdast, document.uri, fontFamily);
                 } else {
                   const exportDocxPath = require("path").join(__dirname, "export-docx.js");
                   const { exportToDocx: doExport } = require(exportDocxPath);
                   await doExport(mdast, document.uri, fontFamily);
                 }
+
+                // Notify webview on success so the button can re-enable without
+                // relying on the 3-second timeout.
+                try {
+                  webviewPanel.webview.postMessage({ type: "exportDone", success: true });
+                } catch {
+                  /* webview may have been disposed */
+                }
               } catch (err) {
                 const errMsg = err instanceof Error ? err.message : String(err);
                 vscode.window.showErrorMessage(`Export thất bại: ${errMsg}`);
                 console.error("[Export]", err);
+                try {
+                  webviewPanel.webview.postMessage({
+                    type: "exportDone",
+                    success: false,
+                    reason: errMsg,
+                  });
+                } catch {
+                  /* webview may have been disposed */
+                }
+              } finally {
+                exportInProgress = false;
               }
             })();
             break;
@@ -972,6 +1024,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           e.affectsConfiguration("tuiMarkdown.highlightCurrentLine")
         ) {
           sendConfig();
+        }
+        if (e.affectsConfiguration("tuiMarkdown.chromiumPath")) {
+          try {
+            const exportPdfPath = require("path").join(__dirname, "export-pdf.js");
+            const { clearChromiumCache } = require(exportPdfPath);
+            clearChromiumCache?.();
+          } catch {
+            /* module may not be loaded yet — cache will be empty anyway */
+          }
         }
       }),
       vscode.workspace.onDidSaveTextDocument(async (savedDoc) => {

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -911,6 +911,55 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             })();
             break;
           }
+          case "export": {
+            const exportMsg = msg as {
+              format?: string;
+              fontFamily?: string;
+              mermaidImages?: { code: string; base64: string }[];
+            };
+            const mermaidImages = exportMsg.mermaidImages || [];
+            const exportFormat = exportMsg.format || "docx";
+            const fontFamily = exportMsg.fontFamily || "";
+
+            // Strip frontmatter
+            const rawText = document.getText();
+            const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+            let bodyForExport = rawText.replace(frontmatterRegex, "");
+
+            // Replace mermaid code blocks with inline images
+            if (mermaidImages.length > 0) {
+              for (const { code, base64 } of mermaidImages) {
+                const escaped = code.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                const mermaidBlockRegex = new RegExp(
+                  "```mermaid\\s*\\n" + escaped + "\\s*\\n```",
+                  "g",
+                );
+                bodyForExport = bodyForExport.replace(
+                  mermaidBlockRegex,
+                  `![Mermaid Diagram](${base64})`,
+                );
+              }
+            }
+
+            (async () => {
+              try {
+                if (exportFormat === "pdf") {
+                  const exportPdfPath = require("path").join(__dirname, "export-pdf.js");
+                  const { exportToPdf: doExport } = require(exportPdfPath);
+                  await doExport(bodyForExport, document.uri, fontFamily);
+                } else {
+                  const exportDocxPath = require("path").join(__dirname, "export-docx.js");
+                  const { exportToDocx: doExport } = require(exportDocxPath);
+                  await doExport(bodyForExport, document.uri, fontFamily);
+                }
+              } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                vscode.window.showErrorMessage(`Export thất bại: ${errMsg}`);
+                console.error("[Export]", err);
+              }
+            })();
+            break;
+          }
         }
       }),
       webviewPanel.onDidChangeViewState((e) => {
@@ -1519,6 +1568,67 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
           .appearance-popover .zoom-display-btn:hover {
             background: rgba(127, 127, 127, 0.22);
+          }
+          /* Export row inside popover */
+          .appearance-popover .export-controls {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+          }
+          .appearance-popover #export-format {
+            flex: 1;
+            -webkit-appearance: none;
+            appearance: none;
+            background-color: rgba(127, 127, 127, 0.15);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 8px center;
+            padding: 4px 28px 4px 10px;
+            border: 1px solid rgba(127, 127, 127, 0.25);
+            border-radius: 6px;
+            height: 30px;
+            color: inherit;
+            cursor: pointer;
+            font-size: 11px;
+          }
+          .appearance-popover #export-format:hover {
+            background-color: rgba(127, 127, 127, 0.22);
+          }
+          .appearance-popover #export-format:focus {
+            border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.6);
+            outline: none;
+          }
+          .appearance-popover #btn-export-go {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px;
+            height: 30px;
+            padding: 0 12px;
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.15);
+            color: var(--accent-primary, var(--vscode-focusBorder, #3b82f6));
+            border: 1px solid rgba(var(--accent-rgb, 59, 130, 246), 0.3);
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            white-space: nowrap;
+            transition: background 0.15s ease-out, transform 0.1s ease-out;
+          }
+          .appearance-popover #btn-export-go:hover {
+            background: rgba(var(--accent-rgb, 59, 130, 246), 0.25);
+          }
+          .appearance-popover #btn-export-go:active {
+            transform: scale(0.95);
+          }
+          .appearance-popover #btn-export-go svg {
+            width: 13px;
+            height: 13px;
+            stroke: currentColor;
+            stroke-width: 2;
+            fill: none;
+            stroke-linecap: round;
+            stroke-linejoin: round;
           }
           #btn-appearance.is-active {
             background: rgba(var(--accent-rgb, 59, 130, 246), 0.18);
@@ -2328,7 +2438,6 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             box-shadow: 0 0 0 1px var(--vscode-focusBorder, rgba(0,122,204,0.3));
           }
           .mermaid-preview svg {
-            max-width: 100%;
             height: auto;
           }
 
@@ -2352,16 +2461,24 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
           .mermaid-svg-host {
             display: block;
+            overflow-x: auto;
+            overflow-y: auto;
           }
           .mermaid-svg-host svg {
-            max-width: 100%;
             height: auto;
+            min-width: min-content;
           }
           /* Allow foreignObject labels to render outside their bbox without
              being clipped by SVG's default overflow:hidden. */
-          .mermaid-svg-host svg,
-          .mermaid-svg-host svg * {
+          .mermaid-svg-host svg foreignObject,
+          .mermaid-svg-host svg text {
             overflow: visible;
+          }
+          .mermaid-svg-host::-webkit-scrollbar { height: 4px; }
+          .mermaid-svg-host::-webkit-scrollbar-track { background: transparent; }
+          .mermaid-svg-host::-webkit-scrollbar-thumb {
+            background: rgba(var(--border-rgb, 0, 0, 0), 0.12);
+            border-radius: 2px;
           }
           .mermaid-expand-btn {
             position: absolute;
@@ -3280,6 +3397,19 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
                 <div class="appearance-row">
                   <label class="appearance-label">Font</label>
                   <div id="font-selector-container"></div>
+                </div>
+                <div class="appearance-row">
+                  <label class="appearance-label">Export</label>
+                  <div class="export-controls">
+                    <select id="export-format" aria-label="Export format">
+                      <option value="docx">DOCX</option>
+                      <option value="pdf">PDF</option>
+                    </select>
+                    <button id="btn-export-go" title="Export file" aria-label="Export">
+                      <svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                      Export
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -921,36 +921,35 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             const exportFormat = exportMsg.format || "docx";
             const fontFamily = exportMsg.fontFamily || "";
 
-            // Strip frontmatter
             const rawText = document.getText();
             const frontmatterRegex = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n?/;
-            let bodyForExport = rawText.replace(frontmatterRegex, "");
-
-            // Replace mermaid code blocks with inline images
-            if (mermaidImages.length > 0) {
-              for (const { code, base64 } of mermaidImages) {
-                const escaped = code.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                const mermaidBlockRegex = new RegExp(
-                  "```mermaid\\s*\\n" + escaped + "\\s*\\n```",
-                  "g",
-                );
-                bodyForExport = bodyForExport.replace(
-                  mermaidBlockRegex,
-                  `![Mermaid Diagram](${base64})`,
-                );
-              }
-            }
+            const bodyMarkdown = rawText.replace(frontmatterRegex, "");
 
             (async () => {
               try {
+                const markdownAstPath = require("path").join(__dirname, "markdown-ast.js");
+                const {
+                  parseMarkdownToMdast,
+                  replaceMermaidBlocks,
+                  hashMermaidCode,
+                  mdastToMarkdown,
+                } = require(markdownAstPath);
+
+                const mdast = await parseMarkdownToMdast(bodyMarkdown);
+                const imageMap = new Map<string, string>(
+                  mermaidImages.map(({ code, base64 }) => [hashMermaidCode(code), base64]),
+                );
+                await replaceMermaidBlocks(mdast, imageMap);
+
                 if (exportFormat === "pdf") {
                   const exportPdfPath = require("path").join(__dirname, "export-pdf.js");
                   const { exportToPdf: doExport } = require(exportPdfPath);
-                  await doExport(bodyForExport, document.uri, fontFamily);
+                  const bridgedMarkdown = await mdastToMarkdown(mdast);
+                  await doExport(bridgedMarkdown, document.uri, fontFamily);
                 } else {
                   const exportDocxPath = require("path").join(__dirname, "export-docx.js");
                   const { exportToDocx: doExport } = require(exportDocxPath);
-                  await doExport(bodyForExport, document.uri, fontFamily);
+                  await doExport(mdast, document.uri, fontFamily);
                 }
               } catch (err) {
                 const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/utils/chromium-discovery.ts
+++ b/src/utils/chromium-discovery.ts
@@ -51,8 +51,8 @@ export async function findChromiumExecutable(): Promise<string | null> {
     }
   }
 
-  cachedPath = null;
-  return cachedPath;
+  // Don't cache misses: user may install a browser during this session
+  return null;
 }
 
 function isExecutable(p: string): boolean {

--- a/src/utils/chromium-discovery.ts
+++ b/src/utils/chromium-discovery.ts
@@ -1,0 +1,109 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
+
+/**
+ * Locate a Chromium-family executable for puppeteer-core.
+ *
+ * VS Code extension host process is an Electron helper, not a stand-alone
+ * Chromium — puppeteer cannot drive it. We therefore need a real browser
+ * binary on the user's machine (Chrome, Edge, Chromium, or Brave).
+ *
+ * Lookup order (first hit wins):
+ *   1. `tuiMarkdown.chromiumPath` setting
+ *   2. PUPPETEER_EXECUTABLE_PATH env var
+ *   3. Well-known OS paths
+ *
+ * Result is cached per extension host session.
+ */
+
+let cachedPath: string | null | undefined;
+
+export function clearChromiumCache(): void {
+  cachedPath = undefined;
+}
+
+/** Strip leading/trailing whitespace and surrounding quotes. */
+function cleanPath(raw: string): string {
+  return raw.trim().replace(/^["']+|["']+$/g, "");
+}
+
+export async function findChromiumExecutable(): Promise<string | null> {
+  if (cachedPath !== undefined) return cachedPath;
+
+  const setting = cleanPath(
+    vscode.workspace.getConfiguration("tuiMarkdown").get<string>("chromiumPath", ""),
+  );
+  if (setting && isExecutable(setting)) {
+    cachedPath = setting;
+    return cachedPath;
+  }
+
+  const envVar = cleanPath(process.env.PUPPETEER_EXECUTABLE_PATH || "");
+  if (envVar && isExecutable(envVar)) {
+    cachedPath = envVar;
+    return cachedPath;
+  }
+
+  for (const candidate of candidatePaths()) {
+    if (isExecutable(candidate)) {
+      cachedPath = candidate;
+      return cachedPath;
+    }
+  }
+
+  cachedPath = null;
+  return cachedPath;
+}
+
+function isExecutable(p: string): boolean {
+  try {
+    const stat = fs.statSync(p);
+    if (!stat.isFile()) return false;
+    // fs.accessSync throws if path cannot be read or executed.
+    // On Windows X_OK is treated as F_OK (file exists); acceptable.
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function candidatePaths(): string[] {
+  const platform = process.platform;
+  if (platform === "darwin") {
+    return [
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+      "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+      "/Applications/Arc.app/Contents/MacOS/Arc",
+    ];
+  }
+  if (platform === "win32") {
+    const pf = process.env["ProgramFiles"] || "C:\\Program Files";
+    const pfx86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    const local = process.env["LOCALAPPDATA"] || "";
+    return [
+      `${pf}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${pfx86}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${local}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${pf}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${pfx86}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${pf}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+      `${pfx86}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+      `${pf}\\Chromium\\Application\\chrome.exe`,
+    ];
+  }
+  return [
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/snap/bin/chromium",
+    "/usr/bin/microsoft-edge",
+    "/usr/bin/microsoft-edge-stable",
+    "/usr/bin/brave-browser",
+    "/opt/google/chrome/chrome",
+  ];
+}

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -3,6 +3,8 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import type { Root } from "mdast";
 
+export type PageSize = "A4" | "Letter";
+
 /**
  * Export an MDAST tree to a DOCX file.
  *
@@ -16,6 +18,7 @@ export async function exportToDocx(
   mdast: Root,
   documentUri: vscode.Uri,
   fontFamily?: string,
+  pageSize?: PageSize,
 ): Promise<void> {
   const docName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
   const defaultUri = vscode.Uri.joinPath(
@@ -57,36 +60,22 @@ export async function exportToDocx(
           import("image-size"),
         ]);
 
-        const imageResolver = createNodeImageResolver(baseDir, imageSize);
+        const imageResolver = createNodeImageResolver(baseDir, imageSize, pageSize);
 
-        const docxProps: Record<string, unknown> = { title: docName };
-        if (fontFamily) {
-          docxProps.styles = {
-            default: {
-              document: {
-                run: { font: fontFamily },
-              },
-            },
-          };
-        }
+        const docxProps = buildDocxProps(docName, fontFamily);
+        const sectionProps = buildSectionProps(pageSize, [
+          blockquotePlugin(),
+          htmlPlugin(),
+          imagePlugin({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            imageResolver: imageResolver as any,
+            cacheConfig: { cacheMode: "memory" },
+          }),
+          tablePlugin(),
+          listPlugin(),
+        ]);
 
-        const result = await toDocx(
-          mdast,
-          docxProps,
-          {
-            plugins: [
-              htmlPlugin(),
-              imagePlugin({
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                imageResolver: imageResolver as any,
-                cacheConfig: { cacheMode: "memory" },
-              }),
-              tablePlugin(),
-              listPlugin(),
-            ],
-          },
-          "uint8array",
-        );
+        const result = await toDocx(mdast, docxProps, sectionProps, "uint8array");
 
         const buffer = Buffer.from(result as Uint8Array);
         await vscode.workspace.fs.writeFile(saveUri, buffer);
@@ -110,6 +99,203 @@ export async function exportToDocx(
     vscode.window.showErrorMessage(`Export failed: ${message}`);
     console.error("[Export DOCX]", err);
   }
+}
+
+// Page size constants. DXA (twips): 1440 DXA = 1 inch.
+const PAGE_SIZES = {
+  A4: { width: 11906, height: 16838 },
+  Letter: { width: 12240, height: 15840 },
+} as const;
+
+const DEFAULT_MARGIN_DXA = 1440; // 1 inch
+
+function contentWidthPx(pageSize?: PageSize): number {
+  const size = pageSize === "Letter" ? PAGE_SIZES.Letter : PAGE_SIZES.A4;
+  const contentDxa = size.width - DEFAULT_MARGIN_DXA * 2;
+  return Math.round((contentDxa / 1440) * 96);
+}
+
+function contentHeightPx(pageSize?: PageSize): number {
+  const size = pageSize === "Letter" ? PAGE_SIZES.Letter : PAGE_SIZES.A4;
+  const contentDxa = size.height - DEFAULT_MARGIN_DXA * 2;
+  return Math.round((contentDxa / 1440) * 96);
+}
+
+/**
+ * Document styles.
+ *
+ * Heading scale mirrors the PDF export (GitHub-like): H1=2x body, H2=1.5x,
+ * H3=1.25x, H4=1.1x, H5=1x, H6=0.9x. Body is 12pt, so H1 lands at 24pt.
+ * This keeps DOCX and PDF visually aligned for the same document.
+ *
+ * Units:
+ *   - `size`: half-points (24 = 12pt).
+ *   - `spacing.before/after`: twips (240 = 12pt; 1440 = 1 inch).
+ *   - `spacing.line`: twips; 240 = single (1.0x), 276 ≈ 1.15x, 360 = 1.5x.
+ *
+ * Heading IDs MUST be `Heading1..Heading6`. mdast2docx maps markdown depth N
+ * directly to `Heading${N}` only when section props set `useTitle: false`
+ * (see buildSectionProps). Without that, H1 falls through to built-in "Title"
+ * and every level is shifted by 1.
+ */
+function buildDocxProps(
+  title: string,
+  fontFamily?: string,
+): Record<string, unknown> {
+  const font = fontFamily || "Arial";
+  const monoFont = "Consolas";
+
+  const headingStyles = [
+    { id: "Heading1", name: "Heading 1", size: 48, spacing: { before: 480, after: 240 }, outlineLevel: 0 }, // 24pt
+    { id: "Heading2", name: "Heading 2", size: 36, spacing: { before: 360, after: 180 }, outlineLevel: 1 }, // 18pt
+    { id: "Heading3", name: "Heading 3", size: 30, spacing: { before: 300, after: 150 }, outlineLevel: 2 }, // 15pt
+    { id: "Heading4", name: "Heading 4", size: 26, spacing: { before: 240, after: 120 }, outlineLevel: 3 }, // 13pt
+    { id: "Heading5", name: "Heading 5", size: 24, spacing: { before: 240, after: 120 }, outlineLevel: 4 }, // 12pt
+    { id: "Heading6", name: "Heading 6", size: 22, spacing: { before: 240, after: 120 }, outlineLevel: 5 }, // 11pt
+  ];
+
+  return {
+    title,
+    styles: {
+      default: {
+        document: {
+          run: { font, size: 24 }, // 12pt body
+          paragraph: {
+            // mdast2docx's built-in default is `alignment: "thaiDistribute"`,
+            // which Word renders as odd wide spacing for Latin/Vietnamese.
+            // Force left alignment and a normal Western gap between paragraphs.
+            alignment: "left",
+            spacing: { before: 120, after: 0, line: 276 }, // 6pt before, 1.15x line
+          },
+        },
+      },
+      paragraphStyles: [
+        ...headingStyles.map((h) => ({
+          id: h.id,
+          name: h.name,
+          basedOn: "Normal",
+          next: "Normal",
+          quickFormat: true,
+          run: { size: h.size, bold: true, font },
+          paragraph: {
+            spacing: h.spacing,
+            outlineLevel: h.outlineLevel,
+            // Keep heading on the same page as the next paragraph so a
+            // heading is never left dangling at the bottom of a page.
+            keepNext: true,
+          },
+        })),
+        // mdast2docx emits code blocks with `style: "blockCode"`. Define it
+        // so fenced code blocks share a consistent mono font + smaller size.
+        {
+          id: "blockCode",
+          name: "Code Block",
+          basedOn: "Normal",
+          next: "Normal",
+          quickFormat: false,
+          run: { font: monoFont, size: 20 }, // 10pt
+          paragraph: {
+            spacing: { before: 120, after: 120, line: 260 },
+            alignment: "left",
+          },
+        },
+      ],
+      characterStyles: [
+        // mdast2docx emits `inlineCode` with `style: "code"` (lowercase,
+        // hardcoded in @m2d/core). Match that id so the shading/color apply.
+        {
+          id: "code",
+          name: "Inline Code",
+          basedOn: "DefaultParagraphFont",
+          run: {
+            font: monoFont,
+            size: 20, // 10pt (slightly smaller than body)
+            color: "C7254E",
+            shading: { type: "clear", fill: "F9F2F4" },
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Custom blockquote handler. mdast2docx's built-in renderer applies
+ * `indent: { left: 720, hanging: 360 }` which indents wrapped lines MORE
+ * than the first line (bibliography-style), and omits `spacing.before`,
+ * so blockquotes sit flush against the preceding paragraph/list.
+ *
+ * We override both: no hanging indent (all lines align), and a 12pt top
+ * gap so the quote breathes away from neighbouring blocks. Setting
+ * `node.type = ""` disables the default case in @m2d/core.
+ */
+function blockquotePlugin(): Record<string, unknown> {
+  return {
+    block: (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      docx: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      node: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      paraProps: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      blockChildrenProcessor: any,
+    ) => {
+      if (node.type !== "blockquote") return [];
+
+      const quoteProps = {
+        ...paraProps,
+        indent: { left: 720 }, // 0.5 inch left, uniform across all lines
+        border: {
+          ...(paraProps.border || {}),
+          left: {
+            style: docx.BorderStyle.SINGLE,
+            size: 12,
+            space: 14,
+            color: "CCCCCC",
+          },
+        },
+        spacing: {
+          ...(paraProps.spacing || {}),
+          before: 240, // 12pt gap above the quote
+          after: 120,  // 6pt gap below
+        },
+      };
+
+      const paragraphs = blockChildrenProcessor(node, quoteProps);
+      node.type = ""; // Prevent @m2d/core's default blockquote branch
+      return paragraphs;
+    },
+  };
+}
+
+/**
+ * Section props. This is the argument 3 of toDocx, NOT docxProps. Page size
+ * and margins belong here because `IDocxProps = Omit<..., "sections" | ...>`.
+ *
+ * `useTitle: false` so markdown depth N maps directly to `Heading${N}`,
+ * aligning with the paragraphStyles in buildDocxProps.
+ */
+function buildSectionProps(
+  pageSize: PageSize | undefined,
+  plugins: unknown[],
+): Record<string, unknown> {
+  const size = pageSize === "Letter" ? PAGE_SIZES.Letter : PAGE_SIZES.A4;
+  return {
+    useTitle: false,
+    plugins,
+    properties: {
+      page: {
+        size: { width: size.width, height: size.height },
+        margin: {
+          top: DEFAULT_MARGIN_DXA,
+          right: DEFAULT_MARGIN_DXA,
+          bottom: DEFAULT_MARGIN_DXA,
+          left: DEFAULT_MARGIN_DXA,
+        },
+      },
+    },
+  };
 }
 
 type ImageResolver = (
@@ -151,7 +337,10 @@ function safeDecodeURIComponent(s: string): string {
 function createNodeImageResolver(
   baseDir: string,
   imageSize: (input: Uint8Array) => { width?: number; height?: number },
+  pageSize?: PageSize,
 ): ImageResolver {
+  const maxWidth = contentWidthPx(pageSize);
+  const maxHeight = contentHeightPx(pageSize);
   return async (src) => {
     try {
       let buffer: Buffer;
@@ -218,7 +407,7 @@ function createNodeImageResolver(
       return {
         data: dataForDocx,
         type,
-        transformation: { width, height },
+        transformation: clampImageSize(width, height, maxWidth, maxHeight),
       };
     } catch (err) {
       console.warn(`[Export DOCX] Skip image "${src.slice(0, 60)}":`, err);
@@ -232,4 +421,27 @@ function normalizeImageType(raw: string): string {
   if (lower === "jpeg") return "jpg";
   if (lower === "svg+xml") return "svg";
   return lower;
+}
+
+/**
+ * Scale image to fit within maxWidth AND maxHeight.
+ * Uses the smaller scale factor to ensure the image fits both dimensions.
+ * Images smaller than both limits are kept at original size.
+ */
+function clampImageSize(
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number,
+): { width: number; height: number } {
+  if (width <= maxWidth && height <= maxHeight) return { width, height };
+
+  const scaleW = width > maxWidth ? maxWidth / width : 1;
+  const scaleH = height > maxHeight ? maxHeight / height : 1;
+  const scale = Math.min(scaleW, scaleH);
+
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
 }

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -197,7 +197,7 @@ function createNodeImageResolver(
       }
 
       if (type === "svg") {
-        console.warn(`[Export DOCX] SVG image không được hỗ trợ, thay bằng placeholder: ${src.slice(0, 60)}`);
+        console.warn(`[Export DOCX] SVG image not supported, using placeholder: ${src.slice(0, 60)}`);
         return placeholderImage();
       }
 
@@ -209,10 +209,10 @@ function createNodeImageResolver(
           width = probed.width;
           height = probed.height;
         } else {
-          console.warn(`[Export DOCX] Không đọc được dimensions, dùng 600x400 cho: ${src.slice(0, 60)}`);
+          console.warn(`[Export DOCX] Cannot read dimensions, using 600x400 for: ${src.slice(0, 60)}`);
         }
       } catch (err) {
-        console.warn(`[Export DOCX] imageSize failed cho "${src.slice(0, 60)}":`, err);
+        console.warn(`[Export DOCX] imageSize failed for "${src.slice(0, 60)}":`, err);
       }
 
       return {

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+/**
+ * Export markdown content to DOCX file.
+ * Uses @m2d/md2docx for conversion (remark-based pipeline).
+ *
+ * This module is bundled as a separate file (out/export-docx.js) and
+ * lazy-loaded on demand to keep the main extension.js small.
+ */
+export async function exportToDocx(
+  markdown: string,
+  documentUri: vscode.Uri,
+  fontFamily?: string,
+): Promise<void> {
+  const docName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
+  const defaultUri = vscode.Uri.joinPath(
+    vscode.Uri.joinPath(documentUri, ".."),
+    `${docName}.docx`,
+  );
+
+  const saveUri = await vscode.window.showSaveDialog({
+    defaultUri,
+    filters: { "Word Document": ["docx"] },
+    title: "Export as DOCX",
+  });
+
+  if (!saveUri) return; // User cancelled
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Exporting DOCX…",
+        cancellable: false,
+      },
+      async () => {
+        const { md2docx } = await import("@m2d/md2docx");
+
+        const docxProps: Record<string, unknown> = { title: docName };
+
+        // Apply user's font preference as default document font
+        if (fontFamily) {
+          docxProps.styles = {
+            default: {
+              document: {
+                run: { font: fontFamily },
+              },
+            },
+          };
+        }
+
+        const result = await md2docx(
+          markdown,
+          docxProps,
+          {},
+          "uint8array",
+        );
+
+        const buffer = Buffer.from(result as Uint8Array);
+        await vscode.workspace.fs.writeFile(saveUri, buffer);
+      },
+    );
+
+    const openAction = await vscode.window.showInformationMessage(
+      `Exported: ${path.basename(saveUri.fsPath)}`,
+      "Open File",
+      "Open Folder",
+    );
+
+    if (openAction === "Open File") {
+      vscode.env.openExternal(saveUri);
+    } else if (openAction === "Open Folder") {
+      const folder = vscode.Uri.joinPath(saveUri, "..");
+      vscode.env.openExternal(folder);
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`Export failed: ${message}`);
+    console.error("[Export DOCX]", err);
+  }
+}

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -102,8 +102,7 @@ export async function exportToDocx(
     if (openAction === "Open File") {
       vscode.env.openExternal(saveUri);
     } else if (openAction === "Open Folder") {
-      const folder = vscode.Uri.joinPath(saveUri, "..");
-      vscode.env.openExternal(folder);
+      await vscode.commands.executeCommand("revealFileInOS", saveUri);
     }
   } catch (err) {
     const message =
@@ -122,60 +121,109 @@ type ImageResolver = (
   transformation: { width: number; height: number };
 }>;
 
+const REMOTE_FETCH_TIMEOUT_MS = 30_000;
+const REMOTE_MAX_BYTES = 10 * 1024 * 1024; // 10MB
+// 1x1 transparent PNG — used when an image cannot be resolved so one broken
+// reference does not kill the whole export.
+const PLACEHOLDER_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+function placeholderImage(): {
+  data: string;
+  type: string;
+  transformation: { width: number; height: number };
+} {
+  return {
+    data: `data:image/png;base64,${PLACEHOLDER_PNG_BASE64}`,
+    type: "png",
+    transformation: { width: 1, height: 1 },
+  };
+}
+
+function safeDecodeURIComponent(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
 function createNodeImageResolver(
   baseDir: string,
   imageSize: (input: Uint8Array) => { width?: number; height?: number },
 ): ImageResolver {
   return async (src) => {
-    let buffer: Buffer;
-    let type: string;
-    let dataForDocx: string | Buffer;
-
-    if (src.startsWith("data:")) {
-      const match = /^data:image\/([\w+-]+);base64,(.+)$/.exec(src);
-      if (!match) throw new Error(`Invalid data URL: ${src.slice(0, 40)}…`);
-      type = normalizeImageType(match[1]);
-      buffer = Buffer.from(match[2], "base64");
-      dataForDocx = src;
-    } else if (/^https?:\/\//i.test(src)) {
-      const res = await fetch(src);
-      if (!res.ok) throw new Error(`Fetch ${res.status} for ${src}`);
-      buffer = Buffer.from(await res.arrayBuffer());
-      const contentType = res.headers.get("content-type") ?? "";
-      const ext = contentType.split("/")[1]?.split(";")[0] ?? "png";
-      type = normalizeImageType(ext);
-      dataForDocx = buffer;
-    } else {
-      const cleaned = src.replace(/^file:\/\//, "");
-      const resolved = path.isAbsolute(cleaned)
-        ? cleaned
-        : path.resolve(baseDir, decodeURIComponent(cleaned));
-      buffer = await fs.readFile(resolved);
-      type = normalizeImageType(path.extname(resolved).slice(1) || "png");
-      dataForDocx = buffer;
-    }
-
-    if (type === "svg") {
-      throw new Error(`SVG images are not supported in DOCX export: ${src.slice(0, 60)}`);
-    }
-
-    let width = 600;
-    let height = 400;
     try {
-      const probed = imageSize(buffer);
-      if (probed.width && probed.height) {
-        width = probed.width;
-        height = probed.height;
-      }
-    } catch {
-      // keep defaults
-    }
+      let buffer: Buffer;
+      let type: string;
+      let dataForDocx: string | Buffer;
 
-    return {
-      data: dataForDocx,
-      type,
-      transformation: { width, height },
-    };
+      if (src.startsWith("data:")) {
+        const match = /^data:image\/([\w+-]+);base64,(.+)$/.exec(src);
+        if (!match) throw new Error(`Invalid data URL: ${src.slice(0, 40)}…`);
+        type = normalizeImageType(match[1]);
+        buffer = Buffer.from(match[2], "base64");
+        dataForDocx = src;
+      } else if (/^https?:\/\//i.test(src)) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+        try {
+          const res = await fetch(src, { signal: controller.signal });
+          if (!res.ok) throw new Error(`Fetch ${res.status} for ${src}`);
+          const declaredSize = Number(res.headers.get("content-length") ?? "0");
+          if (Number.isFinite(declaredSize) && declaredSize > REMOTE_MAX_BYTES) {
+            throw new Error(`Remote image > ${REMOTE_MAX_BYTES} bytes: ${src}`);
+          }
+          const arr = await res.arrayBuffer();
+          if (arr.byteLength > REMOTE_MAX_BYTES) {
+            throw new Error(`Remote image > ${REMOTE_MAX_BYTES} bytes: ${src}`);
+          }
+          buffer = Buffer.from(arr);
+          const contentType = res.headers.get("content-type") ?? "";
+          const ext = contentType.split("/")[1]?.split(";")[0] ?? "png";
+          type = normalizeImageType(ext);
+          dataForDocx = buffer;
+        } finally {
+          clearTimeout(timer);
+        }
+      } else {
+        const cleaned = src.replace(/^file:\/\//, "");
+        const resolved = path.isAbsolute(cleaned)
+          ? cleaned
+          : path.resolve(baseDir, safeDecodeURIComponent(cleaned));
+        buffer = await fs.readFile(resolved);
+        type = normalizeImageType(path.extname(resolved).slice(1) || "png");
+        dataForDocx = buffer;
+      }
+
+      if (type === "svg") {
+        console.warn(`[Export DOCX] SVG image không được hỗ trợ, thay bằng placeholder: ${src.slice(0, 60)}`);
+        return placeholderImage();
+      }
+
+      let width = 600;
+      let height = 400;
+      try {
+        const probed = imageSize(buffer);
+        if (probed.width && probed.height) {
+          width = probed.width;
+          height = probed.height;
+        } else {
+          console.warn(`[Export DOCX] Không đọc được dimensions, dùng 600x400 cho: ${src.slice(0, 60)}`);
+        }
+      } catch (err) {
+        console.warn(`[Export DOCX] imageSize failed cho "${src.slice(0, 60)}":`, err);
+      }
+
+      return {
+        data: dataForDocx,
+        type,
+        transformation: { width, height },
+      };
+    } catch (err) {
+      console.warn(`[Export DOCX] Skip image "${src.slice(0, 60)}":`, err);
+      return placeholderImage();
+    }
   };
 }
 

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as fs from "fs/promises";
 
 /**
  * Export markdown content to DOCX file.
- * Uses @m2d/md2docx for conversion (remark-based pipeline).
  *
- * This module is bundled as a separate file (out/export-docx.js) and
- * lazy-loaded on demand to keep the main extension.js small.
+ * Pipeline: markdown → remark-parse (+gfm,+frontmatter) → MDAST → mdast2docx.toDocx → Uint8Array.
+ * Bundled as a separate file (out/export-docx.js) and lazy-loaded on demand.
  */
 export async function exportToDocx(
   markdown: string,
@@ -25,7 +25,9 @@ export async function exportToDocx(
     title: "Export as DOCX",
   });
 
-  if (!saveUri) return; // User cancelled
+  if (!saveUri) return;
+
+  const baseDir = path.dirname(documentUri.fsPath);
 
   try {
     await vscode.window.withProgress(
@@ -35,11 +37,39 @@ export async function exportToDocx(
         cancellable: false,
       },
       async () => {
-        const { md2docx } = await import("@m2d/md2docx");
+        const [
+          { unified },
+          { default: remarkParse },
+          { default: remarkGfm },
+          { default: remarkFrontmatter },
+          { toDocx },
+          { htmlPlugin },
+          { imagePlugin },
+          { tablePlugin },
+          { listPlugin },
+          { imageSize },
+        ] = await Promise.all([
+          import("unified"),
+          import("remark-parse"),
+          import("remark-gfm"),
+          import("remark-frontmatter"),
+          import("mdast2docx"),
+          import("@m2d/html"),
+          import("@m2d/image"),
+          import("@m2d/table"),
+          import("@m2d/list"),
+          import("image-size"),
+        ]);
+
+        const imageResolver = createNodeImageResolver(baseDir, imageSize);
+
+        const mdast = unified()
+          .use(remarkParse)
+          .use(remarkGfm)
+          .use(remarkFrontmatter, ["yaml"])
+          .parse(markdown);
 
         const docxProps: Record<string, unknown> = { title: docName };
-
-        // Apply user's font preference as default document font
         if (fontFamily) {
           docxProps.styles = {
             default: {
@@ -50,10 +80,21 @@ export async function exportToDocx(
           };
         }
 
-        const result = await md2docx(
-          markdown,
+        const result = await toDocx(
+          mdast,
           docxProps,
-          {},
+          {
+            plugins: [
+              htmlPlugin(),
+              imagePlugin({
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                imageResolver: imageResolver as any,
+                cacheConfig: { cacheMode: "memory" },
+              }),
+              tablePlugin(),
+              listPlugin(),
+            ],
+          },
           "uint8array",
         );
 
@@ -80,4 +121,77 @@ export async function exportToDocx(
     vscode.window.showErrorMessage(`Export failed: ${message}`);
     console.error("[Export DOCX]", err);
   }
+}
+
+type ImageResolver = (
+  src: string,
+  options: unknown,
+) => Promise<{
+  data: string | Buffer;
+  type: string;
+  transformation: { width: number; height: number };
+}>;
+
+function createNodeImageResolver(
+  baseDir: string,
+  imageSize: (input: Uint8Array) => { width?: number; height?: number },
+): ImageResolver {
+  return async (src) => {
+    let buffer: Buffer;
+    let type: string;
+    let dataForDocx: string | Buffer;
+
+    if (src.startsWith("data:")) {
+      const match = /^data:image\/([\w+-]+);base64,(.+)$/.exec(src);
+      if (!match) throw new Error(`Invalid data URL: ${src.slice(0, 40)}…`);
+      type = normalizeImageType(match[1]);
+      buffer = Buffer.from(match[2], "base64");
+      dataForDocx = src;
+    } else if (/^https?:\/\//i.test(src)) {
+      const res = await fetch(src);
+      if (!res.ok) throw new Error(`Fetch ${res.status} for ${src}`);
+      buffer = Buffer.from(await res.arrayBuffer());
+      const contentType = res.headers.get("content-type") ?? "";
+      const ext = contentType.split("/")[1]?.split(";")[0] ?? "png";
+      type = normalizeImageType(ext);
+      dataForDocx = buffer;
+    } else {
+      const cleaned = src.replace(/^file:\/\//, "");
+      const resolved = path.isAbsolute(cleaned)
+        ? cleaned
+        : path.resolve(baseDir, decodeURIComponent(cleaned));
+      buffer = await fs.readFile(resolved);
+      type = normalizeImageType(path.extname(resolved).slice(1) || "png");
+      dataForDocx = buffer;
+    }
+
+    if (type === "svg") {
+      throw new Error(`SVG images are not supported in DOCX export: ${src.slice(0, 60)}`);
+    }
+
+    let width = 600;
+    let height = 400;
+    try {
+      const probed = imageSize(buffer);
+      if (probed.width && probed.height) {
+        width = probed.width;
+        height = probed.height;
+      }
+    } catch {
+      // keep defaults
+    }
+
+    return {
+      data: dataForDocx,
+      type,
+      transformation: { width, height },
+    };
+  };
+}
+
+function normalizeImageType(raw: string): string {
+  const lower = raw.toLowerCase().trim();
+  if (lower === "jpeg") return "jpg";
+  if (lower === "svg+xml") return "svg";
+  return lower;
 }

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -159,7 +159,7 @@ function createNodeImageResolver(
       let dataForDocx: string | Buffer;
 
       if (src.startsWith("data:")) {
-        const match = /^data:image\/([\w+-]+);base64,(.+)$/.exec(src);
+        const match = /^data:image\/([\w+-]+)(?:;[^,]*)?;base64,(.+)$/i.exec(src);
         if (!match) throw new Error(`Invalid data URL: ${src.slice(0, 40)}…`);
         type = normalizeImageType(match[1]);
         buffer = Buffer.from(match[2], "base64");

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -1,15 +1,19 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs/promises";
+import type { Root } from "mdast";
 
 /**
- * Export markdown content to DOCX file.
+ * Export an MDAST tree to a DOCX file.
  *
- * Pipeline: markdown → remark-parse (+gfm,+frontmatter) → MDAST → mdast2docx.toDocx → Uint8Array.
+ * Stage 3: MDAST is parsed once in the extension host (markdown-ast.ts)
+ * and shared between DOCX and PDF exporters, so mermaid substitution
+ * happens on the tree instead of by regex on markdown text.
+ *
  * Bundled as a separate file (out/export-docx.js) and lazy-loaded on demand.
  */
 export async function exportToDocx(
-  markdown: string,
+  mdast: Root,
   documentUri: vscode.Uri,
   fontFamily?: string,
 ): Promise<void> {
@@ -38,10 +42,6 @@ export async function exportToDocx(
       },
       async () => {
         const [
-          { unified },
-          { default: remarkParse },
-          { default: remarkGfm },
-          { default: remarkFrontmatter },
           { toDocx },
           { htmlPlugin },
           { imagePlugin },
@@ -49,10 +49,6 @@ export async function exportToDocx(
           { listPlugin },
           { imageSize },
         ] = await Promise.all([
-          import("unified"),
-          import("remark-parse"),
-          import("remark-gfm"),
-          import("remark-frontmatter"),
           import("mdast2docx"),
           import("@m2d/html"),
           import("@m2d/image"),
@@ -62,12 +58,6 @@ export async function exportToDocx(
         ]);
 
         const imageResolver = createNodeImageResolver(baseDir, imageSize);
-
-        const mdast = unified()
-          .use(remarkParse)
-          .use(remarkGfm)
-          .use(remarkFrontmatter, ["yaml"])
-          .parse(markdown);
 
         const docxProps: Record<string, unknown> = { title: docName };
         if (fontFamily) {

--- a/src/utils/export-docx.ts
+++ b/src/utils/export-docx.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs/promises";
 import type { Root } from "mdast";
+import { extractVscodeResourcePath } from "./vscode-resource";
 
 export type PageSize = "A4" | "Letter";
 
@@ -107,7 +108,7 @@ const PAGE_SIZES = {
   Letter: { width: 12240, height: 15840 },
 } as const;
 
-const DEFAULT_MARGIN_DXA = 1440; // 1 inch
+const DEFAULT_MARGIN_DXA = 1134; // 20mm
 
 function contentWidthPx(pageSize?: PageSize): number {
   const size = pageSize === "Letter" ? PAGE_SIZES.Letter : PAGE_SIZES.A4;
@@ -131,7 +132,7 @@ function contentHeightPx(pageSize?: PageSize): number {
  * Units:
  *   - `size`: half-points (24 = 12pt).
  *   - `spacing.before/after`: twips (240 = 12pt; 1440 = 1 inch).
- *   - `spacing.line`: twips; 240 = single (1.0x), 276 ≈ 1.15x, 360 = 1.5x.
+ *   - `spacing.line`: twips; 240 = single (1.0x), 360 = 1.5x.
  *
  * Heading IDs MUST be `Heading1..Heading6`. mdast2docx maps markdown depth N
  * directly to `Heading${N}` only when section props set `useTitle: false`
@@ -165,7 +166,7 @@ function buildDocxProps(
             // which Word renders as odd wide spacing for Latin/Vietnamese.
             // Force left alignment and a normal Western gap between paragraphs.
             alignment: "left",
-            spacing: { before: 120, after: 0, line: 276 }, // 6pt before, 1.15x line
+            spacing: { before: 0, after: 120, line: 360 }, // 6pt after, 1.5x line
           },
         },
       },
@@ -195,7 +196,7 @@ function buildDocxProps(
           quickFormat: false,
           run: { font: monoFont, size: 20 }, // 10pt
           paragraph: {
-            spacing: { before: 120, after: 120, line: 260 },
+            spacing: { before: 120, after: 120, line: 300 }, // 1.25x line for code
             alignment: "left",
           },
         },
@@ -347,12 +348,19 @@ function createNodeImageResolver(
       let type: string;
       let dataForDocx: string | Buffer;
 
+      // VS Code webview resource URLs — extract local path and read from disk
+      const vscodeLocalPath = extractVscodeResourcePath(src);
+
       if (src.startsWith("data:")) {
         const match = /^data:image\/([\w+-]+)(?:;[^,]*)?;base64,(.+)$/i.exec(src);
         if (!match) throw new Error(`Invalid data URL: ${src.slice(0, 40)}…`);
         type = normalizeImageType(match[1]);
         buffer = Buffer.from(match[2], "base64");
         dataForDocx = src;
+      } else if (vscodeLocalPath) {
+        buffer = await fs.readFile(vscodeLocalPath);
+        type = normalizeImageType(path.extname(vscodeLocalPath).slice(1) || "png");
+        dataForDocx = buffer;
       } else if (/^https?:\/\//i.test(src)) {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -17,11 +17,15 @@ export { clearChromiumCache };
  * Bundled as `out/export-pdf.js` (lazy-loaded on demand).
  */
 
+export type PageSize = "A4" | "Letter";
+
 export async function exportToPdf(
   mdast: Root,
   documentUri: vscode.Uri,
   fontFamily?: string,
+  pageSize?: PageSize,
 ): Promise<void> {
+  const format: PageSize = pageSize === "Letter" ? "Letter" : "A4";
   const docName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
   const defaultUri = vscode.Uri.joinPath(
     vscode.Uri.joinPath(documentUri, ".."),
@@ -62,7 +66,7 @@ export async function exportToPdf(
         const baseDir = path.dirname(documentUri.fsPath);
         const bodyHtml = await mdastToHtml(mdast, baseDir);
         const sanitizedBody = stripDangerousHtmlTags(bodyHtml);
-        const fullHtml = buildHtmlDocument(sanitizedBody, docName, fontFamily);
+        const fullHtml = buildHtmlDocument(sanitizedBody, docName, fontFamily, format);
 
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const puppeteer = require("puppeteer-core");
@@ -88,7 +92,7 @@ export async function exportToPdf(
             timeout: 30_000,
           });
           const pdfBuffer: Uint8Array = await page.pdf({
-            format: "A4",
+            format,
             printBackground: true,
             preferCSSPageSize: false,
             margin: { top: "20mm", right: "15mm", bottom: "20mm", left: "15mm" },
@@ -249,9 +253,13 @@ function buildHtmlDocument(
   bodyHtml: string,
   title: string,
   fontFamily?: string,
+  pageSize?: PageSize,
 ): string {
   const safeTitle = escapeHtml(title);
   const userFont = cssFontFamilyToken(fontFamily);
+  // Page size is set via puppeteer `page.pdf({ format })` with
+  // `preferCSSPageSize: false`. We only use @page here for orphans/widows.
+  void pageSize;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -259,7 +267,9 @@ function buildHtmlDocument(
 <meta charset="utf-8">
 <title>${safeTitle}</title>
 <style>
+${pageCss()}
 ${baseCss(userFont)}
+${printEnhancementsCss()}
 ${codeHighlightCss()}
 </style>
 </head>
@@ -282,6 +292,81 @@ function cssFontFamilyToken(fontFamily: string | undefined): string {
   const sanitized = fontFamily.trim().replace(/[^A-Za-z0-9 _\-]/g, "");
   if (!sanitized) return "";
   return `"${sanitized}", `;
+}
+
+function pageCss(): string {
+  // Page size comes from puppeteer page.pdf({ format }), not CSS, to keep
+  // a single source of truth. @page here only carries print-quality hints.
+  return `
+@page {
+  orphans: 3;
+  widows: 3;
+}
+`;
+}
+
+function printEnhancementsCss(): string {
+  return `
+/* First heading on page — no top margin */
+.markdown-body > h1:first-child,
+.markdown-body > h2:first-child,
+.markdown-body > h3:first-child {
+  margin-top: 0;
+}
+/* Page break helpers */
+h1, h2, h3, h4, h5, h6 {
+  page-break-after: avoid;
+  break-after: avoid;
+}
+p, li, blockquote {
+  orphans: 3;
+  widows: 3;
+}
+table, pre, figure, .alert {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+/* Print-friendly links: show URL after link text (skip links wrapping images) */
+@media print {
+  a[href^="http"]:not(:has(img))::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #57606a;
+    word-break: break-all;
+  }
+}
+/* GFM-style alert / admonition blocks */
+.alert, blockquote:has(> p:first-child > strong:first-child) {
+  border-left: 4px solid #0969da;
+  background: #ddf4ff;
+  padding: 0.6em 1em;
+  margin: 0.5em 0 1em;
+  border-radius: 4px;
+}
+blockquote:has(> p:first-child > strong:first-child:where(
+  :is([data-type="warning"], .warning)
+)) {
+  border-left-color: #d1242f;
+  background: #ffebe9;
+}
+/* Images — ensure they fit within a single page.
+   No explicit height: browsers keep intrinsic aspect-ratio when
+   max-width/max-height clip; explicit height:auto + object-fit can
+   collapse rasterised SVG with missing intrinsic dims. */
+img {
+  max-width: 100%;
+  max-height: 90vh;
+  display: block;
+  margin: 0.5em auto;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+/* Task list checkboxes — print-friendly */
+input[type="checkbox"] {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+`;
 }
 
 function baseCss(userFont: string): string {

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import type { Root } from "mdast";
 import { findChromiumExecutable, clearChromiumCache } from "./chromium-discovery";
+import { extractVscodeResourcePath } from "./vscode-resource";
 
 export { clearChromiumCache };
 
@@ -95,7 +96,7 @@ export async function exportToPdf(
             format,
             printBackground: true,
             preferCSSPageSize: false,
-            margin: { top: "20mm", right: "15mm", bottom: "20mm", left: "15mm" },
+            margin: { top: "20mm", right: "20mm", bottom: "20mm", left: "20mm" },
           });
           await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
         } finally {
@@ -206,6 +207,21 @@ async function inlineRelativeImages(
     imgs.map(async (node) => {
       const src = typeof node.properties.src === "string" ? node.properties.src : "";
       if (!src) return;
+
+      // VS Code webview resource URLs — extract local path and inline from disk
+      const vscodeLocalPath = extractVscodeResourcePath(src);
+      if (vscodeLocalPath) {
+        try {
+          const buf = await fs.readFile(vscodeLocalPath);
+          const ext = (path.extname(vscodeLocalPath).slice(1) || "png").toLowerCase();
+          const mime = ext === "svg" ? "image/svg+xml" : `image/${ext === "jpg" ? "jpeg" : ext}`;
+          node.properties.src = `data:${mime};base64,${buf.toString("base64")}`;
+        } catch (err) {
+          console.warn(`[Export PDF] Failed to read vscode-resource image "${src.slice(0, 60)}":`, err);
+        }
+        return;
+      }
+
       if (/^(?:data:|https?:)/i.test(src)) return;
 
       try {
@@ -352,12 +368,14 @@ blockquote:has(> p:first-child > strong:first-child:where(
 /* Images — ensure they fit within a single page.
    No explicit height: browsers keep intrinsic aspect-ratio when
    max-width/max-height clip; explicit height:auto + object-fit can
-   collapse rasterised SVG with missing intrinsic dims. */
+   collapse rasterised SVG with missing intrinsic dims.
+   Single rule — avoids cascade conflicts from duplicate img selectors. */
 img {
   max-width: 100%;
   max-height: 90vh;
   display: block;
   margin: 0.5em auto;
+  border-radius: 4px;
   page-break-inside: avoid;
   break-inside: avoid;
 }
@@ -381,8 +399,8 @@ html, body {
   background: #fff;
   color: #1f2328;
   font-family: ${userFont}-apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  font-size: 11pt;
-  line-height: 1.625;
+  font-size: 12pt;
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
 .markdown-body {
@@ -402,13 +420,13 @@ h3 { font-size: 1.25em; }
 h4 { font-size: 1em; }
 h5 { font-size: 0.9em; }
 h6 { font-size: 0.85em; color: #57606a; }
-p { margin: 0 0 0.8em; text-wrap: pretty; }
+p { margin: 0 0 0.5em; text-wrap: pretty; }
 a { color: #0969da; text-decoration: underline; }
-ul, ol { margin: 0 0 0.8em; padding-left: 1.6em; }
+ul, ol { margin: 0 0 0.5em; padding-left: 1.6em; }
 li { margin: 0.1em 0; }
 li > p { margin: 0.2em 0; }
 blockquote {
-  margin: 0 0 0.8em;
+  margin: 0 0 0.5em;
   padding: 0.2em 1em;
   color: #57606a;
   border-left: 0.25em solid #d0d7de;
@@ -445,7 +463,7 @@ pre code {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 0 0 0.8em;
+  margin: 0 0 0.5em;
   page-break-inside: avoid;
 }
 th, td {
@@ -456,12 +474,7 @@ th, td {
 }
 th { background: #f6f8fa; font-weight: 600; }
 tr:nth-child(2n) td { background: #f6f8fa; }
-img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 4px;
-  page-break-inside: avoid;
-}
+/* img rule consolidated in printEnhancementsCss */
 input[type="checkbox"] {
   margin-right: 0.3em;
   vertical-align: middle;

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -1,369 +1,24 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import * as fs from "fs";
+import * as fs from "fs/promises";
+import type { Root } from "mdast";
+import { findChromiumExecutable, clearChromiumCache } from "./chromium-discovery";
+
+export { clearChromiumCache };
 
 /**
- * Export markdown content to PDF file.
- * Uses pdfmake (PdfPrinter) with Roboto fonts.
+ * Export an MDAST tree to a PDF file via puppeteer-core.
  *
- * Bundled separately as out/export-pdf.js (lazy-loaded on demand).
+ * Stage 4: replaces the hand-written pdfmake pipeline. MDAST is rendered
+ * to HTML with unified, wrapped in a themed document, then Chromium
+ * prints it to PDF. The extension ships no Chromium binary — we locate
+ * one installed on the user's machine (see `chromium-discovery.ts`).
+ *
+ * Bundled as `out/export-pdf.js` (lazy-loaded on demand).
  */
-
-// ── System font detection ──
-
-/** Font variant paths for pdfmake */
-interface FontVariants {
-  normal: string;
-  bold: string;
-  italics: string;
-  bolditalics: string;
-}
-
-/**
- * Search for a font family in system font directories (macOS / Linux).
- * Returns font variant paths if found, null otherwise.
- */
-function findSystemFont(fontFamily: string): FontVariants | null {
-  const home = require("os").homedir();
-  const fontDirs = [
-    // macOS
-    "/System/Library/Fonts",
-    "/Library/Fonts",
-    path.join(home, "Library", "Fonts"),
-    // Linux
-    "/usr/share/fonts",
-    "/usr/local/share/fonts",
-    path.join(home, ".local", "share", "fonts"),
-    path.join(home, ".fonts"),
-  ];
-
-  // Normalize font name for filename matching: "JetBrains Mono" → "JetBrainsMono"
-  const nameNoSpaces = fontFamily.replace(/\s+/g, "");
-  const nameDashed = fontFamily.replace(/\s+/g, "-");
-
-  // Common variant suffixes
-  const variantPatterns: Record<keyof FontVariants, string[]> = {
-    normal: ["-Regular", "-Normal", "-Book", ""],
-    bold: ["-Bold", "-SemiBold", "-Medium"],
-    italics: ["-Italic", "-RegularItalic", "-It"],
-    bolditalics: ["-BoldItalic", "-BoldIt", "-SemiBoldItalic"],
-  };
-
-  const extensions = [".ttf", ".otf"];
-
-  function findVariant(dirs: string[], basenames: string[], suffixes: string[]): string | null {
-    for (const dir of dirs) {
-      if (!fs.existsSync(dir)) continue;
-      for (const base of basenames) {
-        for (const suffix of suffixes) {
-          for (const ext of extensions) {
-            const filePath = path.join(dir, `${base}${suffix}${ext}`);
-            if (fs.existsSync(filePath)) return filePath;
-          }
-        }
-      }
-      // Also try scanning directory for partial matches
-      try {
-        const files = fs.readdirSync(dir);
-        const lowerFamily = fontFamily.toLowerCase().replace(/\s+/g, "");
-        for (const suffix of suffixes) {
-          const lowerSuffix = suffix.toLowerCase();
-          const match = files.find((f) => {
-            const lf = f.toLowerCase().replace(/\s+/g, "");
-            return lf.includes(lowerFamily) && lf.includes(lowerSuffix) && extensions.some((e) => lf.endsWith(e));
-          });
-          if (match) return path.join(dir, match);
-        }
-      } catch { /* dir not readable */ }
-    }
-    return null;
-  }
-
-  const basenames = [nameNoSpaces, nameDashed, fontFamily];
-
-  // 1. Try to find variable font first (single file for all weights)
-  // Patterns: "Inter-VariableFont_opsz,wght.ttf", "JetBrainsMono[wght].ttf"
-  for (const dir of fontDirs) {
-    if (!fs.existsSync(dir)) continue;
-    try {
-      const files = fs.readdirSync(dir);
-      const lowerFamily = fontFamily.toLowerCase().replace(/\s+/g, "");
-      // Find non-italic variable font
-      const varFont = files.find((f) => {
-        const lf = f.toLowerCase().replace(/\s+/g, "");
-        return lf.includes(lowerFamily)
-          && !lf.includes("italic")
-          && (lf.includes("variablefont") || lf.includes("[wght]"))
-          && extensions.some((e) => lf.endsWith(e));
-      });
-      if (varFont) {
-        const varPath = path.join(dir, varFont);
-        // Try to find italic variable font too
-        const italicVarFont = files.find((f) => {
-          const lf = f.toLowerCase().replace(/\s+/g, "");
-          return lf.includes(lowerFamily)
-            && lf.includes("italic")
-            && (lf.includes("variablefont") || lf.includes("[wght]"))
-            && extensions.some((e) => lf.endsWith(e));
-        });
-        const italicPath = italicVarFont ? path.join(dir, italicVarFont) : varPath;
-        return { normal: varPath, bold: varPath, italics: italicPath, bolditalics: italicPath };
-      }
-    } catch { /* dir not readable */ }
-  }
-
-  // 2. Fall back to static font variants
-  const normalPath = findVariant(fontDirs, basenames, variantPatterns.normal);
-  if (!normalPath) return null;
-
-  const boldPath = findVariant(fontDirs, basenames, variantPatterns.bold) || normalPath;
-  const italicPath = findVariant(fontDirs, basenames, variantPatterns.italics) || normalPath;
-  const boldItalicPath = findVariant(fontDirs, basenames, variantPatterns.bolditalics) || boldPath;
-
-  return {
-    normal: normalPath,
-    bold: boldPath,
-    italics: italicPath,
-    bolditalics: boldItalicPath,
-  };
-}
-
-
-interface PdfContent {
-  text?: string | PdfContent[];
-  style?: string;
-  bold?: boolean;
-  italics?: boolean;
-  fontSize?: number;
-  font?: string;
-  margin?: number[];
-  ul?: PdfContent[];
-  ol?: PdfContent[];
-  table?: { headerRows?: number; widths?: (string | number)[]; body: PdfContent[][] };
-  layout?: string;
-  image?: string;
-  width?: number;
-  color?: string;
-  decoration?: string;
-  fillColor?: string;
-  alignment?: string;
-  lineHeight?: number;
-  preserveLeadingSpaces?: boolean;
-  [key: string]: unknown;
-}
-
-/** Parse simple markdown to pdfmake document content array. */
-function markdownToPdfContent(md: string): PdfContent[] {
-  const lines = md.split("\n");
-  const content: PdfContent[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // Empty line
-    if (line.trim() === "") { i++; continue; }
-
-    // Heading
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const sizes = [22, 18, 16, 14, 13, 12];
-      content.push({
-        text: parseInline(headingMatch[2]),
-        fontSize: sizes[level - 1],
-        bold: true,
-        margin: [0, level <= 2 ? 16 : 10, 0, 6],
-        color: "#1a1a1a",
-      });
-      i++; continue;
-    }
-
-    // Image (standalone)
-    const imgMatch = line.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
-    if (imgMatch) {
-      const src = imgMatch[2];
-      if (src.startsWith("data:")) {
-        content.push({ image: src, width: 450, margin: [0, 8, 0, 8], alignment: "center" });
-      }
-      i++; continue;
-    }
-
-    // Code block
-    if (line.startsWith("```")) {
-      const codeLines: string[] = [];
-      i++;
-      while (i < lines.length && !lines[i].startsWith("```")) {
-        codeLines.push(lines[i]);
-        i++;
-      }
-      i++; // skip closing ```
-      content.push({
-        text: codeLines.join("\n"),
-        fontSize: 9,
-        color: "#2d2d2d",
-        fillColor: "#f5f5f5",
-        margin: [0, 4, 0, 8],
-        lineHeight: 1.4,
-        preserveLeadingSpaces: true,
-      });
-      continue;
-    }
-
-    // Table
-    if (line.includes("|") && i + 1 < lines.length && lines[i + 1]?.match(/^\|?\s*[-:]+/)) {
-      const tableContent = parseTable(lines, i);
-      if (tableContent) {
-        content.push(tableContent.node);
-        i = tableContent.endIndex;
-        continue;
-      }
-    }
-
-    // Unordered list
-    if (line.match(/^\s*[-*+]\s/)) {
-      const items: PdfContent[] = [];
-      while (i < lines.length && lines[i].match(/^\s*[-*+]\s/)) {
-        const text = lines[i].replace(/^\s*[-*+]\s+/, "");
-        // Task list
-        if (text.startsWith("[ ] ") || text.startsWith("[x] ")) {
-          const checked = text.startsWith("[x] ");
-          const label = text.slice(4);
-          items.push({
-            text: [
-              { text: checked ? "☑ " : "☐ ", bold: true },
-              ...parseInline(label),
-            ],
-          });
-        } else {
-          items.push({ text: parseInline(text) });
-        }
-        i++;
-      }
-      content.push({ ul: items, margin: [0, 4, 0, 8] });
-      continue;
-    }
-
-    // Ordered list
-    if (line.match(/^\s*\d+\.\s/)) {
-      const items: PdfContent[] = [];
-      while (i < lines.length && lines[i].match(/^\s*\d+\.\s/)) {
-        const text = lines[i].replace(/^\s*\d+\.\s+/, "");
-        items.push({ text: parseInline(text) });
-        i++;
-      }
-      content.push({ ol: items, margin: [0, 4, 0, 8] });
-      continue;
-    }
-
-    // Blockquote
-    if (line.startsWith("> ")) {
-      const quoteLines: string[] = [];
-      while (i < lines.length && lines[i].startsWith("> ")) {
-        quoteLines.push(lines[i].slice(2));
-        i++;
-      }
-      content.push({
-        text: parseInline(quoteLines.join(" ")),
-        italics: true,
-        color: "#555",
-        margin: [20, 4, 0, 8],
-      });
-      continue;
-    }
-
-    // Horizontal rule
-    if (line.match(/^[-*_]{3,}\s*$/)) {
-      content.push({
-        text: "",
-        margin: [0, 8, 0, 8],
-      });
-      // Simple separator via canvas would be ideal but keep it simple
-      i++; continue;
-    }
-
-    // Normal paragraph
-    content.push({
-      text: parseInline(line),
-      margin: [0, 0, 0, 6],
-      lineHeight: 1.5,
-    });
-    i++;
-  }
-
-  return content;
-}
-
-/** Parse inline markdown (bold, italic, code, links). */
-function parseInline(text: string): PdfContent[] {
-  const parts: PdfContent[] = [];
-  // Pattern: **bold**, *italic*, `code`, [text](url), ~~strike~~
-  const regex = /(\*\*(.+?)\*\*|\*(.+?)\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\)|~~(.+?)~~)/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ text: text.slice(lastIndex, match.index) });
-    }
-    if (match[2]) { // **bold**
-      parts.push({ text: match[2], bold: true });
-    } else if (match[3]) { // *italic*
-      parts.push({ text: match[3], italics: true });
-    } else if (match[4]) { // `code`
-      parts.push({ text: match[4], fontSize: 10, color: "#c7254e", fillColor: "#f9f2f4" });
-    } else if (match[5] && match[6]) { // [text](url)
-      parts.push({ text: match[5], color: "#2563eb", decoration: "underline" });
-    } else if (match[7]) { // ~~strike~~
-      parts.push({ text: match[7], decoration: "lineThrough" });
-    }
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < text.length) {
-    parts.push({ text: text.slice(lastIndex) });
-  }
-
-  return parts.length > 0 ? parts : [{ text }];
-}
-
-/** Parse markdown table starting at line index. */
-function parseTable(lines: string[], startIndex: number): { node: PdfContent; endIndex: number } | null {
-  const parseRow = (line: string): string[] =>
-    line.split("|").map(c => c.trim()).filter((_, i, arr) => i > 0 && i < arr.length);
-
-  const headerCells = parseRow(lines[startIndex]);
-  if (headerCells.length === 0) return null;
-
-  // Skip separator line
-  let i = startIndex + 2;
-  const bodyRows: string[][] = [];
-  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
-    bodyRows.push(parseRow(lines[i]));
-    i++;
-  }
-
-  const widths = headerCells.map(() => "*" as string | number);
-  const headerRow: PdfContent[] = headerCells.map(c => ({ text: c, bold: true, fillColor: "#f0f0f0" }));
-  const body: PdfContent[][] = [headerRow];
-  for (const row of bodyRows) {
-    body.push(row.map(c => ({ text: c })));
-  }
-
-  return {
-    node: {
-      table: { headerRows: 1, widths, body },
-      layout: "lightHorizontalLines",
-      margin: [0, 8, 0, 12],
-    },
-    endIndex: i,
-  };
-}
-
-// ── Export function ──
 
 export async function exportToPdf(
-  markdown: string,
+  mdast: Root,
   documentUri: vscode.Uri,
   fontFamily?: string,
 ): Promise<void> {
@@ -381,6 +36,21 @@ export async function exportToPdf(
 
   if (!saveUri) return;
 
+  const chromiumPath = await findChromiumExecutable();
+  if (!chromiumPath) {
+    const action = await vscode.window.showErrorMessage(
+      "Cần Chrome, Edge hoặc Chromium đã cài trên máy để export PDF. Cài xong hoặc cấu hình \"tuiMarkdown.chromiumPath\" rồi thử lại.",
+      "Mở Settings",
+    );
+    if (action === "Mở Settings") {
+      await vscode.commands.executeCommand(
+        "workbench.action.openSettings",
+        "tuiMarkdown.chromiumPath",
+      );
+    }
+    return;
+  }
+
   try {
     await vscode.window.withProgress(
       {
@@ -389,62 +59,46 @@ export async function exportToPdf(
         cancellable: false,
       },
       async () => {
-        const pm = require("pdfmake");
+        const baseDir = path.dirname(documentUri.fsPath);
+        const bodyHtml = await mdastToHtml(mdast, baseDir);
+        const sanitizedBody = stripDangerousHtmlTags(bodyHtml);
+        const fullHtml = buildHtmlDocument(sanitizedBody, docName, fontFamily);
 
-        // Bundled Roboto as fallback
-        const bundledFontsDir = path.join(__dirname, "fonts");
-        const robotoFonts = {
-          Roboto: {
-            normal: path.join(bundledFontsDir, "Roboto-Regular.ttf"),
-            bold: path.join(bundledFontsDir, "Roboto-Medium.ttf"),
-            italics: path.join(bundledFontsDir, "Roboto-Italic.ttf"),
-            bolditalics: path.join(bundledFontsDir, "Roboto-MediumItalic.ttf"),
-          },
-        };
-
-        // Try to find user's preferred font on the system
-        let activeFontName = "Roboto";
-        const systemFont = fontFamily ? findSystemFont(fontFamily) : null;
-
-        if (systemFont) {
-          activeFontName = fontFamily!;
-          pm.setFonts({
-            ...robotoFonts,
-            [fontFamily!]: systemFont,
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const puppeteer = require("puppeteer-core");
+        let browser;
+        try {
+          browser = await puppeteer.launch({
+            executablePath: chromiumPath,
+            headless: true,
+            args: puppeteerLaunchArgs(),
           });
-        } else {
-          pm.setFonts(robotoFonts);
+        } catch (launchErr) {
+          const original = launchErr instanceof Error ? launchErr.message : String(launchErr);
+          throw new Error(
+            `Không khởi chạy được Chromium tại "${chromiumPath}": ${original}. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath.`,
+          );
         }
 
-        const pdfContent = markdownToPdfContent(markdown);
-
-        const docDefinition = {
-          content: pdfContent,
-          defaultStyle: {
-            font: activeFontName,
-            fontSize: 11,
-            lineHeight: 1.4,
-            color: "#333",
-          },
-          pageSize: "A4" as const,
-          pageMargins: [50, 50, 50, 50] as [number, number, number, number],
-          info: {
-            title: docName,
-            creator: "TUI Markdown Editor",
-          },
-        };
-
-        const doc = pm.createPdf(docDefinition);
-
-        // pdfmake 0.3.x doc.write() writes to a file path
-        const tmpFile = path.join(
-          require("os").tmpdir(),
-          `tui-export-${Date.now()}.pdf`,
-        );
-        await doc.write(tmpFile);
-        const pdfBuffer = fs.readFileSync(tmpFile);
-        await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
-        try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+        try {
+          const page = await browser.newPage();
+          await page.setJavaScriptEnabled(false);
+          await page.setContent(fullHtml, {
+            waitUntil: "networkidle0",
+            timeout: 30_000,
+          });
+          const pdfBuffer: Uint8Array = await page.pdf({
+            format: "A4",
+            printBackground: true,
+            preferCSSPageSize: false,
+            margin: { top: "20mm", right: "15mm", bottom: "20mm", left: "15mm" },
+          });
+          await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
+        } finally {
+          await browser.close().catch(() => {
+            /* ignore close errors */
+          });
+        }
       },
     );
 
@@ -457,12 +111,298 @@ export async function exportToPdf(
     if (openAction === "Open File") {
       vscode.env.openExternal(saveUri);
     } else if (openAction === "Open Folder") {
-      const folder = vscode.Uri.joinPath(saveUri, "..");
-      vscode.env.openExternal(folder);
+      await vscode.commands.executeCommand("revealFileInOS", saveUri);
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`Export PDF failed: ${message}`);
     console.error("[Export PDF]", err);
   }
+}
+
+/** Only disable Chromium sandbox when we genuinely need to (Linux as root). */
+function puppeteerLaunchArgs(): string[] {
+  const args: string[] = [];
+  const isLinux = process.platform === "linux";
+  const getuid = (process as unknown as { getuid?: () => number }).getuid;
+  const isRoot = typeof getuid === "function" && getuid() === 0;
+  if (isLinux && isRoot) {
+    args.push("--no-sandbox", "--disable-setuid-sandbox");
+  }
+  return args;
+}
+
+/**
+ * Remove the HTML tags that could leak local resources or trigger navigation
+ * even with JavaScript disabled in Chromium (iframes/links still fetch URLs,
+ * meta refresh still navigates, object/embed can load plugins).
+ *
+ * This is a narrow allow-by-default strip — not a full sanitizer. Safe enough
+ * paired with `page.setJavaScriptEnabled(false)` for PDF printing.
+ */
+function stripDangerousHtmlTags(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, "")
+    .replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe\s*>/gi, "")
+    .replace(/<iframe\b[^>]*\/?\s*>/gi, "")
+    .replace(/<object\b[^>]*>[\s\S]*?<\/object\s*>/gi, "")
+    .replace(/<embed\b[^>]*\/?\s*>/gi, "")
+    .replace(/<link\b[^>]*\/?\s*>/gi, "")
+    .replace(/<base\b[^>]*\/?\s*>/gi, "")
+    .replace(/<meta\b[^>]*http-equiv\s*=[^>]*>/gi, "");
+}
+
+async function mdastToHtml(mdast: Root, baseDir: string): Promise<string> {
+  const [
+    { unified },
+    { default: remarkRehype },
+    { default: rehypeHighlight },
+    { default: rehypeStringify },
+  ] = await Promise.all([
+    import("unified"),
+    import("remark-rehype"),
+    import("rehype-highlight"),
+    import("rehype-stringify"),
+  ]);
+
+  const hast = await unified()
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeHighlight, { detect: false, ignoreMissing: true })
+    .run(mdast);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await inlineRelativeImages(hast as any, baseDir);
+
+  const file = unified()
+    .use(rehypeStringify, { allowDangerousHtml: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .stringify(hast as any);
+
+  return String(file);
+}
+
+/**
+ * Chromium loaded via `page.setContent` sits at `about:blank`, so relative
+ * image src attributes (e.g. `./images/foo.png`) cannot be fetched. Inline
+ * them as `data:` URLs from disk before the HTML reaches the browser.
+ */
+async function inlineRelativeImages(
+  hast: { type: string; tagName?: string; properties?: Record<string, unknown>; children?: unknown[] },
+  baseDir: string,
+): Promise<void> {
+  const imgs: { properties: Record<string, unknown> }[] = [];
+  collectImgNodes(hast, imgs);
+
+  await Promise.all(
+    imgs.map(async (node) => {
+      const src = typeof node.properties.src === "string" ? node.properties.src : "";
+      if (!src) return;
+      if (/^(?:data:|https?:|file:)/i.test(src)) return;
+
+      try {
+        const cleaned = src.replace(/^file:\/\//, "");
+        const resolved = path.isAbsolute(cleaned)
+          ? cleaned
+          : path.resolve(baseDir, safeDecode(cleaned));
+        const buf = await fs.readFile(resolved);
+        const ext = (path.extname(resolved).slice(1) || "png").toLowerCase();
+        const mime = ext === "svg" ? "image/svg+xml" : `image/${ext === "jpg" ? "jpeg" : ext}`;
+        node.properties.src = `data:${mime};base64,${buf.toString("base64")}`;
+      } catch (err) {
+        console.warn(`[Export PDF] Không đọc được ảnh "${src}":`, err);
+      }
+    }),
+  );
+}
+
+function collectImgNodes(
+  node: { type: string; tagName?: string; properties?: Record<string, unknown>; children?: unknown[] },
+  out: { properties: Record<string, unknown> }[],
+): void {
+  if (node.type === "element" && node.tagName === "img" && node.properties) {
+    out.push({ properties: node.properties });
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      collectImgNodes(
+        child as { type: string; tagName?: string; properties?: Record<string, unknown>; children?: unknown[] },
+        out,
+      );
+    }
+  }
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+function buildHtmlDocument(
+  bodyHtml: string,
+  title: string,
+  fontFamily?: string,
+): string {
+  const safeTitle = escapeHtml(title);
+  const userFont = cssFontFamilyToken(fontFamily);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${safeTitle}</title>
+<style>
+${baseCss(userFont)}
+${codeHighlightCss()}
+</style>
+</head>
+<body>
+<article class="markdown-body">
+${bodyHtml}
+</article>
+</body>
+</html>`;
+}
+
+/**
+ * Produce a CSS-safe `font-family` prefix (ending with ", " for concatenation)
+ * or an empty string. `escapeHtml` is wrong inside a `<style>` element because
+ * CSS does not decode HTML entities; also any character outside a small
+ * whitelist is stripped to keep the declaration valid.
+ */
+function cssFontFamilyToken(fontFamily: string | undefined): string {
+  if (!fontFamily) return "";
+  const sanitized = fontFamily.trim().replace(/[^A-Za-z0-9 _\-]/g, "");
+  if (!sanitized) return "";
+  return `"${sanitized}", `;
+}
+
+function baseCss(userFont: string): string {
+  return `
+:root {
+  color-scheme: light;
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  color: #1f2328;
+  font-family: ${userFont}-apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  font-size: 11pt;
+  line-height: 1.625;
+  -webkit-font-smoothing: antialiased;
+}
+.markdown-body {
+  max-width: 100%;
+  padding: 0;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 1.6em 0 0.5em;
+  page-break-after: avoid;
+  text-wrap: balance;
+}
+h1 { font-size: 2em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
+h2 { font-size: 1.5em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
+h3 { font-size: 1.25em; }
+h4 { font-size: 1em; }
+h5 { font-size: 0.9em; }
+h6 { font-size: 0.85em; color: #57606a; }
+p { margin: 0 0 0.8em; text-wrap: pretty; }
+a { color: #0969da; text-decoration: underline; }
+ul, ol { margin: 0 0 0.8em; padding-left: 1.6em; }
+li { margin: 0.1em 0; }
+li > p { margin: 0.2em 0; }
+blockquote {
+  margin: 0 0 0.8em;
+  padding: 0.2em 1em;
+  color: #57606a;
+  border-left: 0.25em solid #d0d7de;
+  background: #f6f8fa;
+}
+hr {
+  border: 0;
+  border-top: 2px dashed #d0d7de;
+  margin: 1.5em 0;
+}
+code {
+  font-family: "Cascadia Code", "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em;
+  background: rgba(175, 184, 193, 0.2);
+  border-radius: 4px;
+  padding: 0.15em 0.4em;
+}
+pre {
+  font-family: "Cascadia Code", "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  line-height: 1.5;
+  background: #f6f8fa;
+  border-radius: 6px;
+  padding: 12px 14px;
+  overflow: auto;
+  page-break-inside: avoid;
+}
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0 0 0.8em;
+  page-break-inside: avoid;
+}
+th, td {
+  border: 1px solid #d0d7de;
+  padding: 6px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+th { background: #f6f8fa; font-weight: 600; }
+tr:nth-child(2n) td { background: #f6f8fa; }
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  page-break-inside: avoid;
+}
+input[type="checkbox"] {
+  margin-right: 0.3em;
+  vertical-align: middle;
+}
+ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0.4em; }
+li.task-list-item { list-style: none; }
+`;
+}
+
+/** GitHub-like highlight.js palette, tuned for print. */
+function codeHighlightCss(): string {
+  return `
+.hljs { color: #1f2328; background: transparent; }
+.hljs-comment, .hljs-quote { color: #6a737d; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-type { color: #d73a49; }
+.hljs-string, .hljs-template-string, .hljs-attr { color: #032f62; }
+.hljs-number, .hljs-variable, .hljs-template-variable { color: #005cc5; }
+.hljs-title, .hljs-name, .hljs-section, .hljs-function, .hljs-class .hljs-title { color: #6f42c1; }
+.hljs-tag { color: #22863a; }
+.hljs-symbol, .hljs-bullet, .hljs-meta { color: #e36209; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 600; }
+.hljs-link { text-decoration: underline; }
+`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -39,10 +39,10 @@ export async function exportToPdf(
   const chromiumPath = await findChromiumExecutable();
   if (!chromiumPath) {
     const action = await vscode.window.showErrorMessage(
-      "Cần Chrome, Edge hoặc Chromium đã cài trên máy để export PDF. Cài xong hoặc cấu hình \"tuiMarkdown.chromiumPath\" rồi thử lại.",
-      "Mở Settings",
+      "Chrome, Edge or Chromium must be installed to export PDF. Install one or configure \"tuiMarkdown.chromiumPath\" and try again.",
+      "Open Settings",
     );
-    if (action === "Mở Settings") {
+    if (action === "Open Settings") {
       await vscode.commands.executeCommand(
         "workbench.action.openSettings",
         "tuiMarkdown.chromiumPath",
@@ -76,7 +76,7 @@ export async function exportToPdf(
         } catch (launchErr) {
           const original = launchErr instanceof Error ? launchErr.message : String(launchErr);
           throw new Error(
-            `Không khởi chạy được Chromium tại "${chromiumPath}": ${original}. Kiểm tra quyền execute hoặc cấu hình tuiMarkdown.chromiumPath.`,
+            `Failed to launch Chromium at "${chromiumPath}": ${original}. Check execute permission or configure tuiMarkdown.chromiumPath.`,
           );
         }
 
@@ -209,7 +209,7 @@ async function inlineRelativeImages(
         const mime = ext === "svg" ? "image/svg+xml" : `image/${ext === "jpg" ? "jpeg" : ext}`;
         node.properties.src = `data:${mime};base64,${buf.toString("base64")}`;
       } catch (err) {
-        console.warn(`[Export PDF] Không đọc được ảnh "${src}":`, err);
+        console.warn(`[Export PDF] Failed to read image "${src}":`, err);
       }
     }),
   );

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -1,0 +1,468 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+
+/**
+ * Export markdown content to PDF file.
+ * Uses pdfmake (PdfPrinter) with Roboto fonts.
+ *
+ * Bundled separately as out/export-pdf.js (lazy-loaded on demand).
+ */
+
+// ── System font detection ──
+
+/** Font variant paths for pdfmake */
+interface FontVariants {
+  normal: string;
+  bold: string;
+  italics: string;
+  bolditalics: string;
+}
+
+/**
+ * Search for a font family in system font directories (macOS / Linux).
+ * Returns font variant paths if found, null otherwise.
+ */
+function findSystemFont(fontFamily: string): FontVariants | null {
+  const home = require("os").homedir();
+  const fontDirs = [
+    // macOS
+    "/System/Library/Fonts",
+    "/Library/Fonts",
+    path.join(home, "Library", "Fonts"),
+    // Linux
+    "/usr/share/fonts",
+    "/usr/local/share/fonts",
+    path.join(home, ".local", "share", "fonts"),
+    path.join(home, ".fonts"),
+  ];
+
+  // Normalize font name for filename matching: "JetBrains Mono" → "JetBrainsMono"
+  const nameNoSpaces = fontFamily.replace(/\s+/g, "");
+  const nameDashed = fontFamily.replace(/\s+/g, "-");
+
+  // Common variant suffixes
+  const variantPatterns: Record<keyof FontVariants, string[]> = {
+    normal: ["-Regular", "-Normal", "-Book", ""],
+    bold: ["-Bold", "-SemiBold", "-Medium"],
+    italics: ["-Italic", "-RegularItalic", "-It"],
+    bolditalics: ["-BoldItalic", "-BoldIt", "-SemiBoldItalic"],
+  };
+
+  const extensions = [".ttf", ".otf"];
+
+  function findVariant(dirs: string[], basenames: string[], suffixes: string[]): string | null {
+    for (const dir of dirs) {
+      if (!fs.existsSync(dir)) continue;
+      for (const base of basenames) {
+        for (const suffix of suffixes) {
+          for (const ext of extensions) {
+            const filePath = path.join(dir, `${base}${suffix}${ext}`);
+            if (fs.existsSync(filePath)) return filePath;
+          }
+        }
+      }
+      // Also try scanning directory for partial matches
+      try {
+        const files = fs.readdirSync(dir);
+        const lowerFamily = fontFamily.toLowerCase().replace(/\s+/g, "");
+        for (const suffix of suffixes) {
+          const lowerSuffix = suffix.toLowerCase();
+          const match = files.find((f) => {
+            const lf = f.toLowerCase().replace(/\s+/g, "");
+            return lf.includes(lowerFamily) && lf.includes(lowerSuffix) && extensions.some((e) => lf.endsWith(e));
+          });
+          if (match) return path.join(dir, match);
+        }
+      } catch { /* dir not readable */ }
+    }
+    return null;
+  }
+
+  const basenames = [nameNoSpaces, nameDashed, fontFamily];
+
+  // 1. Try to find variable font first (single file for all weights)
+  // Patterns: "Inter-VariableFont_opsz,wght.ttf", "JetBrainsMono[wght].ttf"
+  for (const dir of fontDirs) {
+    if (!fs.existsSync(dir)) continue;
+    try {
+      const files = fs.readdirSync(dir);
+      const lowerFamily = fontFamily.toLowerCase().replace(/\s+/g, "");
+      // Find non-italic variable font
+      const varFont = files.find((f) => {
+        const lf = f.toLowerCase().replace(/\s+/g, "");
+        return lf.includes(lowerFamily)
+          && !lf.includes("italic")
+          && (lf.includes("variablefont") || lf.includes("[wght]"))
+          && extensions.some((e) => lf.endsWith(e));
+      });
+      if (varFont) {
+        const varPath = path.join(dir, varFont);
+        // Try to find italic variable font too
+        const italicVarFont = files.find((f) => {
+          const lf = f.toLowerCase().replace(/\s+/g, "");
+          return lf.includes(lowerFamily)
+            && lf.includes("italic")
+            && (lf.includes("variablefont") || lf.includes("[wght]"))
+            && extensions.some((e) => lf.endsWith(e));
+        });
+        const italicPath = italicVarFont ? path.join(dir, italicVarFont) : varPath;
+        return { normal: varPath, bold: varPath, italics: italicPath, bolditalics: italicPath };
+      }
+    } catch { /* dir not readable */ }
+  }
+
+  // 2. Fall back to static font variants
+  const normalPath = findVariant(fontDirs, basenames, variantPatterns.normal);
+  if (!normalPath) return null;
+
+  const boldPath = findVariant(fontDirs, basenames, variantPatterns.bold) || normalPath;
+  const italicPath = findVariant(fontDirs, basenames, variantPatterns.italics) || normalPath;
+  const boldItalicPath = findVariant(fontDirs, basenames, variantPatterns.bolditalics) || boldPath;
+
+  return {
+    normal: normalPath,
+    bold: boldPath,
+    italics: italicPath,
+    bolditalics: boldItalicPath,
+  };
+}
+
+
+interface PdfContent {
+  text?: string | PdfContent[];
+  style?: string;
+  bold?: boolean;
+  italics?: boolean;
+  fontSize?: number;
+  font?: string;
+  margin?: number[];
+  ul?: PdfContent[];
+  ol?: PdfContent[];
+  table?: { headerRows?: number; widths?: (string | number)[]; body: PdfContent[][] };
+  layout?: string;
+  image?: string;
+  width?: number;
+  color?: string;
+  decoration?: string;
+  fillColor?: string;
+  alignment?: string;
+  lineHeight?: number;
+  preserveLeadingSpaces?: boolean;
+  [key: string]: unknown;
+}
+
+/** Parse simple markdown to pdfmake document content array. */
+function markdownToPdfContent(md: string): PdfContent[] {
+  const lines = md.split("\n");
+  const content: PdfContent[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Empty line
+    if (line.trim() === "") { i++; continue; }
+
+    // Heading
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const sizes = [22, 18, 16, 14, 13, 12];
+      content.push({
+        text: parseInline(headingMatch[2]),
+        fontSize: sizes[level - 1],
+        bold: true,
+        margin: [0, level <= 2 ? 16 : 10, 0, 6],
+        color: "#1a1a1a",
+      });
+      i++; continue;
+    }
+
+    // Image (standalone)
+    const imgMatch = line.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
+    if (imgMatch) {
+      const src = imgMatch[2];
+      if (src.startsWith("data:")) {
+        content.push({ image: src, width: 450, margin: [0, 8, 0, 8], alignment: "center" });
+      }
+      i++; continue;
+    }
+
+    // Code block
+    if (line.startsWith("```")) {
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing ```
+      content.push({
+        text: codeLines.join("\n"),
+        fontSize: 9,
+        color: "#2d2d2d",
+        fillColor: "#f5f5f5",
+        margin: [0, 4, 0, 8],
+        lineHeight: 1.4,
+        preserveLeadingSpaces: true,
+      });
+      continue;
+    }
+
+    // Table
+    if (line.includes("|") && i + 1 < lines.length && lines[i + 1]?.match(/^\|?\s*[-:]+/)) {
+      const tableContent = parseTable(lines, i);
+      if (tableContent) {
+        content.push(tableContent.node);
+        i = tableContent.endIndex;
+        continue;
+      }
+    }
+
+    // Unordered list
+    if (line.match(/^\s*[-*+]\s/)) {
+      const items: PdfContent[] = [];
+      while (i < lines.length && lines[i].match(/^\s*[-*+]\s/)) {
+        const text = lines[i].replace(/^\s*[-*+]\s+/, "");
+        // Task list
+        if (text.startsWith("[ ] ") || text.startsWith("[x] ")) {
+          const checked = text.startsWith("[x] ");
+          const label = text.slice(4);
+          items.push({
+            text: [
+              { text: checked ? "☑ " : "☐ ", bold: true },
+              ...parseInline(label),
+            ],
+          });
+        } else {
+          items.push({ text: parseInline(text) });
+        }
+        i++;
+      }
+      content.push({ ul: items, margin: [0, 4, 0, 8] });
+      continue;
+    }
+
+    // Ordered list
+    if (line.match(/^\s*\d+\.\s/)) {
+      const items: PdfContent[] = [];
+      while (i < lines.length && lines[i].match(/^\s*\d+\.\s/)) {
+        const text = lines[i].replace(/^\s*\d+\.\s+/, "");
+        items.push({ text: parseInline(text) });
+        i++;
+      }
+      content.push({ ol: items, margin: [0, 4, 0, 8] });
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith("> ")) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith("> ")) {
+        quoteLines.push(lines[i].slice(2));
+        i++;
+      }
+      content.push({
+        text: parseInline(quoteLines.join(" ")),
+        italics: true,
+        color: "#555",
+        margin: [20, 4, 0, 8],
+      });
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.match(/^[-*_]{3,}\s*$/)) {
+      content.push({
+        text: "",
+        margin: [0, 8, 0, 8],
+      });
+      // Simple separator via canvas would be ideal but keep it simple
+      i++; continue;
+    }
+
+    // Normal paragraph
+    content.push({
+      text: parseInline(line),
+      margin: [0, 0, 0, 6],
+      lineHeight: 1.5,
+    });
+    i++;
+  }
+
+  return content;
+}
+
+/** Parse inline markdown (bold, italic, code, links). */
+function parseInline(text: string): PdfContent[] {
+  const parts: PdfContent[] = [];
+  // Pattern: **bold**, *italic*, `code`, [text](url), ~~strike~~
+  const regex = /(\*\*(.+?)\*\*|\*(.+?)\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\)|~~(.+?)~~)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ text: text.slice(lastIndex, match.index) });
+    }
+    if (match[2]) { // **bold**
+      parts.push({ text: match[2], bold: true });
+    } else if (match[3]) { // *italic*
+      parts.push({ text: match[3], italics: true });
+    } else if (match[4]) { // `code`
+      parts.push({ text: match[4], fontSize: 10, color: "#c7254e", fillColor: "#f9f2f4" });
+    } else if (match[5] && match[6]) { // [text](url)
+      parts.push({ text: match[5], color: "#2563eb", decoration: "underline" });
+    } else if (match[7]) { // ~~strike~~
+      parts.push({ text: match[7], decoration: "lineThrough" });
+    }
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ text: text.slice(lastIndex) });
+  }
+
+  return parts.length > 0 ? parts : [{ text }];
+}
+
+/** Parse markdown table starting at line index. */
+function parseTable(lines: string[], startIndex: number): { node: PdfContent; endIndex: number } | null {
+  const parseRow = (line: string): string[] =>
+    line.split("|").map(c => c.trim()).filter((_, i, arr) => i > 0 && i < arr.length);
+
+  const headerCells = parseRow(lines[startIndex]);
+  if (headerCells.length === 0) return null;
+
+  // Skip separator line
+  let i = startIndex + 2;
+  const bodyRows: string[][] = [];
+  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
+    bodyRows.push(parseRow(lines[i]));
+    i++;
+  }
+
+  const widths = headerCells.map(() => "*" as string | number);
+  const headerRow: PdfContent[] = headerCells.map(c => ({ text: c, bold: true, fillColor: "#f0f0f0" }));
+  const body: PdfContent[][] = [headerRow];
+  for (const row of bodyRows) {
+    body.push(row.map(c => ({ text: c })));
+  }
+
+  return {
+    node: {
+      table: { headerRows: 1, widths, body },
+      layout: "lightHorizontalLines",
+      margin: [0, 8, 0, 12],
+    },
+    endIndex: i,
+  };
+}
+
+// ── Export function ──
+
+export async function exportToPdf(
+  markdown: string,
+  documentUri: vscode.Uri,
+  fontFamily?: string,
+): Promise<void> {
+  const docName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
+  const defaultUri = vscode.Uri.joinPath(
+    vscode.Uri.joinPath(documentUri, ".."),
+    `${docName}.pdf`,
+  );
+
+  const saveUri = await vscode.window.showSaveDialog({
+    defaultUri,
+    filters: { "PDF Document": ["pdf"] },
+    title: "Export as PDF",
+  });
+
+  if (!saveUri) return;
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Exporting PDF…",
+        cancellable: false,
+      },
+      async () => {
+        const pm = require("pdfmake");
+
+        // Bundled Roboto as fallback
+        const bundledFontsDir = path.join(__dirname, "fonts");
+        const robotoFonts = {
+          Roboto: {
+            normal: path.join(bundledFontsDir, "Roboto-Regular.ttf"),
+            bold: path.join(bundledFontsDir, "Roboto-Medium.ttf"),
+            italics: path.join(bundledFontsDir, "Roboto-Italic.ttf"),
+            bolditalics: path.join(bundledFontsDir, "Roboto-MediumItalic.ttf"),
+          },
+        };
+
+        // Try to find user's preferred font on the system
+        let activeFontName = "Roboto";
+        const systemFont = fontFamily ? findSystemFont(fontFamily) : null;
+
+        if (systemFont) {
+          activeFontName = fontFamily!;
+          pm.setFonts({
+            ...robotoFonts,
+            [fontFamily!]: systemFont,
+          });
+        } else {
+          pm.setFonts(robotoFonts);
+        }
+
+        const pdfContent = markdownToPdfContent(markdown);
+
+        const docDefinition = {
+          content: pdfContent,
+          defaultStyle: {
+            font: activeFontName,
+            fontSize: 11,
+            lineHeight: 1.4,
+            color: "#333",
+          },
+          pageSize: "A4" as const,
+          pageMargins: [50, 50, 50, 50] as [number, number, number, number],
+          info: {
+            title: docName,
+            creator: "TUI Markdown Editor",
+          },
+        };
+
+        const doc = pm.createPdf(docDefinition);
+
+        // pdfmake 0.3.x doc.write() writes to a file path
+        const tmpFile = path.join(
+          require("os").tmpdir(),
+          `tui-export-${Date.now()}.pdf`,
+        );
+        await doc.write(tmpFile);
+        const pdfBuffer = fs.readFileSync(tmpFile);
+        await vscode.workspace.fs.writeFile(saveUri, pdfBuffer);
+        try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      },
+    );
+
+    const openAction = await vscode.window.showInformationMessage(
+      `Exported: ${path.basename(saveUri.fsPath)}`,
+      "Open File",
+      "Open Folder",
+    );
+
+    if (openAction === "Open File") {
+      vscode.env.openExternal(saveUri);
+    } else if (openAction === "Open Folder") {
+      const folder = vscode.Uri.joinPath(saveUri, "..");
+      vscode.env.openExternal(folder);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`Export PDF failed: ${message}`);
+    console.error("[Export PDF]", err);
+  }
+}

--- a/src/utils/export-pdf.ts
+++ b/src/utils/export-pdf.ts
@@ -149,7 +149,12 @@ function stripDangerousHtmlTags(html: string): string {
     .replace(/<embed\b[^>]*\/?\s*>/gi, "")
     .replace(/<link\b[^>]*\/?\s*>/gi, "")
     .replace(/<base\b[^>]*\/?\s*>/gi, "")
-    .replace(/<meta\b[^>]*http-equiv\s*=[^>]*>/gi, "");
+    .replace(/<meta\b[^>]*http-equiv\s*=[^>]*>/gi, "")
+    // Strip inline event handlers (onclick, onerror, onload, …)
+    .replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    // Neutralise javascript: and data: URLs in href/src attributes
+    .replace(/(href|src)\s*=\s*(?:"\s*javascript:[^"]*"|'\s*javascript:[^']*')/gi, '$1=""')
+    .replace(/(href|src)\s*=\s*(?:"\s*data:text\/html[^"]*"|'\s*data:text\/html[^']*')/gi, '$1=""');
 }
 
 async function mdastToHtml(mdast: Root, baseDir: string): Promise<string> {
@@ -197,7 +202,7 @@ async function inlineRelativeImages(
     imgs.map(async (node) => {
       const src = typeof node.properties.src === "string" ? node.properties.src : "";
       if (!src) return;
-      if (/^(?:data:|https?:|file:)/i.test(src)) return;
+      if (/^(?:data:|https?:)/i.test(src)) return;
 
       try {
         const cleaned = src.replace(/^file:\/\//, "");

--- a/src/utils/markdown-ast.ts
+++ b/src/utils/markdown-ast.ts
@@ -1,0 +1,92 @@
+import type { Code, Image, Paragraph, Parent, Root } from "mdast";
+
+/**
+ * Shared MDAST pipeline for DOCX/PDF export.
+ *
+ * Parsing once in the extension host guarantees the two exporters
+ * produce the same structure (Stage 3: remove regex-replace drift
+ * between webview text and export text).
+ */
+
+export async function parseMarkdownToMdast(markdown: string): Promise<Root> {
+  const [{ unified }, { default: remarkParse }, { default: remarkGfm }, { default: remarkFrontmatter }] =
+    await Promise.all([
+      import("unified"),
+      import("remark-parse"),
+      import("remark-gfm"),
+      import("remark-frontmatter"),
+    ]);
+
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkFrontmatter, ["yaml"])
+    .parse(markdown) as Root;
+}
+
+/**
+ * Serialize MDAST back to markdown (Stage 4 bridge for PDF while
+ * the legacy string-based PDF parser is still in place).
+ * GFM plugin required so tables and task lists survive roundtrip.
+ */
+export async function mdastToMarkdown(mdast: Root): Promise<string> {
+  const [{ unified }, { default: remarkStringify }, { default: remarkGfm }] = await Promise.all([
+    import("unified"),
+    import("remark-stringify"),
+    import("remark-gfm"),
+  ]);
+
+  return unified().use(remarkStringify).use(remarkGfm).stringify(mdast) as string;
+}
+
+/**
+ * djb2 hash (32-bit unsigned, hex).
+ * Used to correlate mermaid code blocks with pre-rendered images
+ * sent from the webview. Both sides must trim the code identically.
+ */
+export function hashMermaidCode(code: string): string {
+  let h = 5381;
+  const trimmed = code.trim();
+  for (let i = 0; i < trimmed.length; i++) {
+    h = (h << 5) + h + trimmed.charCodeAt(i);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Walk the tree and swap `code` nodes with lang="mermaid" for
+ * `image` nodes pointing at the matching base64 data URL.
+ * Mutates in place.
+ *
+ * Mermaid blocks without a matching rendered image stay as code
+ * blocks (graceful degradation for parse errors in the webview).
+ */
+export async function replaceMermaidBlocks(
+  mdast: Root,
+  imageMap: Map<string, string>,
+): Promise<void> {
+  if (imageMap.size === 0) return;
+
+  const { visit, SKIP } = await import("unist-util-visit");
+
+  visit(mdast, "code", (node: Code, index, parent: Parent | null | undefined) => {
+    if (!parent || index === undefined || node.lang !== "mermaid") return;
+
+    const url = imageMap.get(hashMermaidCode(node.value));
+    if (!url) return;
+
+    const imageNode: Image = {
+      type: "image",
+      url,
+      alt: "Mermaid Diagram",
+    };
+    // Wrap in a paragraph so the tree remains schema-valid:
+    // `code` is block-level, `image` is phrasing and must live inside a paragraph.
+    const paragraphNode: Paragraph = {
+      type: "paragraph",
+      children: [imageNode],
+    };
+    parent.children[index] = paragraphNode;
+    return SKIP;
+  });
+}

--- a/src/utils/markdown-ast.ts
+++ b/src/utils/markdown-ast.ts
@@ -25,30 +25,19 @@ export async function parseMarkdownToMdast(markdown: string): Promise<Root> {
 }
 
 /**
- * Serialize MDAST back to markdown (Stage 4 bridge for PDF while
- * the legacy string-based PDF parser is still in place).
- * GFM plugin required so tables and task lists survive roundtrip.
- */
-export async function mdastToMarkdown(mdast: Root): Promise<string> {
-  const [{ unified }, { default: remarkStringify }, { default: remarkGfm }] = await Promise.all([
-    import("unified"),
-    import("remark-stringify"),
-    import("remark-gfm"),
-  ]);
-
-  return unified().use(remarkStringify).use(remarkGfm).stringify(mdast) as string;
-}
-
-/**
  * djb2 hash (32-bit unsigned, hex).
- * Used to correlate mermaid code blocks with pre-rendered images
- * sent from the webview. Both sides must trim the code identically.
+ *
+ * Used to correlate mermaid code blocks with pre-rendered images sent from
+ * the webview. Both sides pipe through this function so the CRLF/LF line
+ * ending the user's file happens to carry does not cause a miss between
+ * `node.textContent` (ProseMirror in the webview) and `node.value`
+ * (remark-parse in the extension host).
  */
 export function hashMermaidCode(code: string): string {
+  const normalized = code.replace(/\r\n?/g, "\n").trim();
   let h = 5381;
-  const trimmed = code.trim();
-  for (let i = 0; i < trimmed.length; i++) {
-    h = (h << 5) + h + trimmed.charCodeAt(i);
+  for (let i = 0; i < normalized.length; i++) {
+    h = (h << 5) + h + normalized.charCodeAt(i);
   }
   return (h >>> 0).toString(16);
 }

--- a/src/utils/markdown-ast.ts
+++ b/src/utils/markdown-ast.ts
@@ -28,13 +28,17 @@ export async function parseMarkdownToMdast(markdown: string): Promise<Root> {
  * djb2 hash (32-bit unsigned, hex).
  *
  * Used to correlate mermaid code blocks with pre-rendered images sent from
- * the webview. Both sides pipe through this function so the CRLF/LF line
- * ending the user's file happens to carry does not cause a miss between
- * `node.textContent` (ProseMirror in the webview) and `node.value`
- * (remark-parse in the extension host).
+ * the webview. Normalizes line endings (CRLF/CR), strips zero-width and
+ * bidi formatting chars, and applies Unicode NFC so ProseMirror's
+ * `node.textContent` and remark-parse's `node.value` hash identically
+ * regardless of platform or invisible-char pastes.
  */
 export function hashMermaidCode(code: string): string {
-  const normalized = code.replace(/\r\n?/g, "\n").trim();
+  const normalized = code
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
+    .normalize("NFC")
+    .trim();
   let h = 5381;
   for (let i = 0; i < normalized.length; i++) {
     h = (h << 5) + h + normalized.charCodeAt(i);
@@ -43,9 +47,32 @@ export function hashMermaidCode(code: string): string {
 }
 
 /**
+ * Count mermaid code blocks in the tree. Used by the caller to detect
+ * when some diagrams did not make it through (render race, parse error,
+ * or hash mismatch) and surface a warning.
+ */
+export function countMermaidBlocks(mdast: Root): number {
+  let count = 0;
+  walkCodeNodes(mdast, (node) => {
+    if (node.lang === "mermaid") count++;
+  });
+  return count;
+}
+
+function walkCodeNodes(root: Root, visit: (node: Code) => void): void {
+  const stack: unknown[] = [root];
+  while (stack.length) {
+    const node = stack.pop() as { type?: string; children?: unknown[] } & Partial<Code>;
+    if (!node || typeof node !== "object") continue;
+    if (node.type === "code") visit(node as Code);
+    if (Array.isArray(node.children)) stack.push(...node.children);
+  }
+}
+
+/**
  * Walk the tree and swap `code` nodes with lang="mermaid" for
  * `image` nodes pointing at the matching base64 data URL.
- * Mutates in place.
+ * Mutates in place. Returns the number of blocks successfully replaced.
  *
  * Mermaid blocks without a matching rendered image stay as code
  * blocks (graceful degradation for parse errors in the webview).
@@ -53,10 +80,12 @@ export function hashMermaidCode(code: string): string {
 export async function replaceMermaidBlocks(
   mdast: Root,
   imageMap: Map<string, string>,
-): Promise<void> {
-  if (imageMap.size === 0) return;
+): Promise<number> {
+  if (imageMap.size === 0) return 0;
 
   const { visit, SKIP } = await import("unist-util-visit");
+
+  let replaced = 0;
 
   visit(mdast, "code", (node: Code, index, parent: Parent | null | undefined) => {
     if (!parent || index === undefined || node.lang !== "mermaid") return;
@@ -76,6 +105,9 @@ export async function replaceMermaidBlocks(
       children: [imageNode],
     };
     parent.children[index] = paragraphNode;
+    replaced++;
     return SKIP;
   });
+
+  return replaced;
 }

--- a/src/utils/markdown-ast.ts
+++ b/src/utils/markdown-ast.ts
@@ -20,7 +20,7 @@ export async function parseMarkdownToMdast(markdown: string): Promise<Root> {
   return unified()
     .use(remarkParse)
     .use(remarkGfm)
-    .use(remarkFrontmatter, ["yaml"])
+    .use(remarkFrontmatter, ["yaml", "toml"])
     .parse(markdown) as Root;
 }
 

--- a/src/utils/vscode-resource.ts
+++ b/src/utils/vscode-resource.ts
@@ -1,0 +1,20 @@
+/**
+ * Detect VS Code webview resource URLs and extract the local file path.
+ *
+ * The webview rewrites local paths like `/Users/foo/img.png` into URLs such as
+ * `https://file+.vscode-resource.vscode-cdn.net/Users/foo/img.png` (or the
+ * percent-encoded variant `file%2B`). These are NOT fetchable over HTTP so we
+ * need to read the file directly from disk.
+ *
+ * Returns the decoded local path, or `null` if the URL is not a vscode-resource URL.
+ */
+export function extractVscodeResourcePath(src: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(src);
+  } catch {
+    decoded = src;
+  }
+  const match = /^https?:\/\/file\+\.vscode-resource\.vscode-(?:cdn|webview)\.net(\/.*)/i.exec(decoded);
+  return match ? match[1] : null;
+}

--- a/src/webview/image-lightbox-plugin.ts
+++ b/src/webview/image-lightbox-plugin.ts
@@ -70,7 +70,7 @@ async function copyCurrentMermaidToClipboard(button: HTMLButtonElement): Promise
     }
   } catch (err) {
     reportCopyError(
-      `Copy mermaid thất bại: ${
+      `Failed to copy mermaid diagram: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1414,6 +1414,7 @@ function setupToolbarHandlers(): void {
 
       // Collect all rendered mermaid diagrams as PNG base64
       const mermaidImages: { code: string; base64: string }[] = [];
+      let skippedMermaidCount = 0;
       const previews = Array.from(document.querySelectorAll<HTMLElement>(".mermaid-preview[data-rendered='true']"));
       for (const preview of previews) {
         const code = preview.getAttribute("data-mermaid-src");
@@ -1428,9 +1429,16 @@ function setupToolbarHandlers(): void {
             reader.readAsDataURL(blob);
           });
           mermaidImages.push({ code: code.trim(), base64 });
-        } catch {
-          // Skip failed mermaid renders
+        } catch (err) {
+          skippedMermaidCount++;
+          console.warn("[Export] Failed to rasterize Mermaid diagram:", err);
         }
+      }
+      if (skippedMermaidCount > 0) {
+        vscode.postMessage({
+          type: "showWarning",
+          message: `${skippedMermaidCount} Mermaid diagram(s) could not be embedded in the export.`,
+        });
       }
       const fontFamily = vscode.getState()?.fontFamily || "";
       vscode.postMessage({ type: "export", format, fontFamily, mermaidImages });

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -187,7 +187,7 @@ document.addEventListener("mermaid-copy-error", (e: Event) => {
   const detail = (e as CustomEvent<{ message?: string }>).detail;
   vscode.postMessage({
     type: "showWarning",
-    message: detail?.message || "Copy mermaid thất bại",
+    message: detail?.message || "Failed to copy mermaid diagram",
   });
 });
 
@@ -1690,7 +1690,7 @@ window.addEventListener("message", async (event) => {
             }
             // Update TOC after content change (skip if just initialized — initTocSidebar already did it)
             if (!justInitialized) updateTocFromEditor(editor, true);
-            // Cập nhật số lượng kết quả tìm kiếm nếu search bar đang hiển thị
+            // Update search result count if search bar is visible
             const searchBar = document.getElementById("search-bar");
             if (searchBar && !searchBar.classList.contains("hidden")) {
               const searchCount = document.getElementById("search-count");

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1403,6 +1403,11 @@ function setupToolbarHandlers(): void {
   exportBtn?.addEventListener("click", async () => {
     if (!exportBtn || exportBtn.disabled) return;
     exportBtn.disabled = true;
+    // Safety net: re-enable after 60s even if extension never responds.
+    // The normal path re-enables via the `exportDone` message listener below.
+    const safetyTimer = window.setTimeout(() => {
+      if (exportBtn) exportBtn.disabled = false;
+    }, 60_000);
     try {
       const formatSelect = document.getElementById("export-format") as HTMLSelectElement | null;
       const format = formatSelect?.value || "docx";
@@ -1429,11 +1434,13 @@ function setupToolbarHandlers(): void {
       }
       const fontFamily = vscode.getState()?.fontFamily || "";
       vscode.postMessage({ type: "export", format, fontFamily, mermaidImages });
-    } finally {
-      setTimeout(() => {
-        if (exportBtn) exportBtn.disabled = false;
-      }, 3000);
+    } catch (err) {
+      window.clearTimeout(safetyTimer);
+      if (exportBtn) exportBtn.disabled = false;
+      throw err;
     }
+    // The safety timer is cleared inside the `exportDone` handler.
+    (exportBtn as HTMLButtonElement & { _safetyTimer?: number })._safetyTimer = safetyTimer;
   });
 
   // Font selector
@@ -1609,6 +1616,20 @@ function scrollToHeading(slug: string): void {
 window.addEventListener("message", async (event) => {
   const message = event.data;
   if (!message || typeof message !== "object") return;
+
+  if (message.type === "exportDone") {
+    const btn = document.getElementById("btn-export-go") as
+      | (HTMLButtonElement & { _safetyTimer?: number })
+      | null;
+    if (btn) {
+      if (btn._safetyTimer !== undefined) {
+        window.clearTimeout(btn._safetyTimer);
+        btn._safetyTimer = undefined;
+      }
+      btn.disabled = false;
+    }
+    return;
+  }
 
   switch (message.type) {
     case "update":

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -866,7 +866,7 @@ function applyHeadingSizes(sizes: Record<string, number>): void {
 
 // Editor initialization
 function initEditor(initialContent: string = ""): Editor | null {
-  console.log("[Tiptap] Starting initialization...");
+
   const editorEl = getEditorEl();
   if (!editorEl) {
     console.error("[Tiptap] Editor element not found");
@@ -1072,7 +1072,7 @@ function initEditor(initialContent: string = ""): Editor | null {
     });
 
     hideLoading();
-    console.log("[Tiptap] Editor created successfully!");
+
     return instance;
   } catch (error) {
     console.error("[Tiptap] Failed to create editor:", error);
@@ -1856,7 +1856,7 @@ function initTocSidebar(): void {
 }
 
 function init() {
-  console.log("[Tiptap] init() called");
+
 
   const savedState = vscode.getState();
   if (savedState?.theme && THEMES.includes(savedState.theme as ThemeName)) {
@@ -1910,11 +1910,11 @@ function init() {
     vscode.postMessage({ type: "readClipboardImage" });
   }, { capture: true });
 
-  console.log("[Tiptap] init() complete, sending ready signal");
+
   vscode.postMessage({ type: "ready" });
 }
 
-console.log("[Tiptap] Script loaded, readyState:", document.readyState);
+
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", init);
 } else {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -50,6 +50,7 @@ import { CodeBlockEnhancement } from "./code-block-plugin";
 import { SearchPlugin, performSearch, clearSearch, searchNext, searchPrev, getMatchInfo } from "./search-plugin";
 import { initFontSelector, type FontSelectorAPI, sanitizeFontName } from "./font-selector";
 import { initLightbox } from "./image-lightbox-plugin";
+import { svgToPngBlob } from "./svg-to-png";
 
 // Fix: @tiptap/markdown v3.19.0 drops `escape` tokens from marked parser,
 // causing escaped characters like \_ to be silently lost during roundtrip.
@@ -1396,6 +1397,44 @@ function setupToolbarHandlers(): void {
   });
 
   getSourceBtn()?.addEventListener("click", viewSource);
+
+  // Export (DOCX/PDF) from appearance popover
+  const exportBtn = document.getElementById("btn-export-go") as HTMLButtonElement | null;
+  exportBtn?.addEventListener("click", async () => {
+    if (!exportBtn || exportBtn.disabled) return;
+    exportBtn.disabled = true;
+    try {
+      const formatSelect = document.getElementById("export-format") as HTMLSelectElement | null;
+      const format = formatSelect?.value || "docx";
+
+      // Collect all rendered mermaid diagrams as PNG base64
+      const mermaidImages: { code: string; base64: string }[] = [];
+      const previews = Array.from(document.querySelectorAll<HTMLElement>(".mermaid-preview[data-rendered='true']"));
+      for (const preview of previews) {
+        const code = preview.getAttribute("data-mermaid-src");
+        const svgEl = preview.querySelector("svg");
+        if (!code || !svgEl) continue;
+        try {
+          const blob = await svgToPngBlob(svgEl.outerHTML, 2);
+          const reader = new FileReader();
+          const base64: string = await new Promise((resolve, reject) => {
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          });
+          mermaidImages.push({ code: code.trim(), base64 });
+        } catch {
+          // Skip failed mermaid renders
+        }
+      }
+      const fontFamily = vscode.getState()?.fontFamily || "";
+      vscode.postMessage({ type: "export", format, fontFamily, mermaidImages });
+    } finally {
+      setTimeout(() => {
+        if (exportBtn) exportBtn.disabled = false;
+      }, 3000);
+    }
+  });
 
   // Font selector
   const fontContainer = document.getElementById("font-selector-container");

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1412,7 +1412,10 @@ function setupToolbarHandlers(): void {
       const formatSelect = document.getElementById("export-format") as HTMLSelectElement | null;
       const format = formatSelect?.value || "docx";
 
-      // Collect all rendered mermaid diagrams as PNG base64
+      // Collect all rendered mermaid diagrams as PNG base64.
+      // Only previews with data-rendered='true' have a usable SVG; the
+      // extension will warn the user about blocks that fall through
+      // (race with 500ms render debounce, or mermaid parse errors).
       const mermaidImages: { code: string; base64: string }[] = [];
       let skippedMermaidCount = 0;
       const previews = Array.from(document.querySelectorAll<HTMLElement>(".mermaid-preview[data-rendered='true']"));

--- a/src/webview/mermaid-plugin.ts
+++ b/src/webview/mermaid-plugin.ts
@@ -277,47 +277,54 @@ export const MermaidDiagram = Extension.create({
                     // decorations (they can be outside editorView.dom in the DOM tree)
                     document.addEventListener("dblclick", handleDblClick);
 
+                    function scanAndSchedule(view: any): void {
+                        const isDark = document.body.classList.contains("dark-theme");
+                        if (!mermaidInitialized) ensureMermaidInit(isDark);
+
+                        // Skip expensive scan when no mermaid blocks exist
+                        if (mermaidBlockCount === 0) return;
+
+                        // After decorations are applied, find preview containers and render
+                        requestAnimationFrame(() => {
+                            const doc = view.state.doc;
+                            doc.descendants((node: any, pos: number) => {
+                                if (node.type.name !== "codeBlock" || node.attrs.language !== "mermaid") return;
+
+                                const code = node.textContent.trim();
+                                if (!code) return;
+
+                                const endPos = pos + node.nodeSize;
+                                const widget = document.querySelector(
+                                    `.mermaid-preview[data-pos="${endPos}"]`
+                                ) as HTMLElement | null;
+                                if (!widget) return;
+
+                                if (widget.getAttribute("data-mermaid-src") === code) return;
+
+                                widget.setAttribute("data-mermaid-src", code);
+
+                                const prev = pendingTimers.get(endPos);
+                                if (prev) clearTimeout(prev);
+
+                                const timer = setTimeout(() => {
+                                    renderMermaid(widget, code);
+                                    pendingTimers.delete(endPos);
+                                }, RENDER_DEBOUNCE_MS);
+
+                                pendingTimers.set(endPos, timer);
+                            });
+                        });
+                    }
+
+                    // Initial scan: ProseMirror does NOT call plugin view's update() on
+                    // view creation, only on subsequent transactions. Without this, mermaid
+                    // blocks present in the initial content stay stuck at "Rendering…" until
+                    // the user triggers another transaction (e.g. clicks inside a block).
+                    scanAndSchedule(editorView);
+
                     return {
                         update(view) {
-                            const isDark = document.body.classList.contains("dark-theme");
-                            if (!mermaidInitialized) ensureMermaidInit(isDark);
-
-                            // Skip expensive scan when no mermaid blocks exist
-                            if (mermaidBlockCount === 0) return;
-
-                            // After decorations are applied, find preview containers and render
-                            requestAnimationFrame(() => {
-                                const doc = view.state.doc;
-                                doc.descendants((node, pos) => {
-                                    if (node.type.name !== "codeBlock" || node.attrs.language !== "mermaid") return;
-
-                                    const code = node.textContent.trim();
-                                    if (!code) return;
-
-                                    const endPos = pos + node.nodeSize;
-                                    // Find the widget element for this position
-                                    const widget = document.querySelector(
-                                        `.mermaid-preview[data-pos="${endPos}"]`
-                                    ) as HTMLElement | null;
-                                    if (!widget) return;
-
-                                    // Check if already rendered with same code
-                                    if (widget.getAttribute("data-mermaid-src") === code) return;
-
-                                    widget.setAttribute("data-mermaid-src", code);
-
-                                    // Cancel previous pending render for this position
-                                    const prev = pendingTimers.get(endPos);
-                                    if (prev) clearTimeout(prev);
-
-                                    const timer = setTimeout(() => {
-                                        renderMermaid(widget, code);
-                                        pendingTimers.delete(endPos);
-                                    }, RENDER_DEBOUNCE_MS);
-
-                                    pendingTimers.set(endPos, timer);
-                                });
-                            });
+                            scanAndSchedule(view);
                         },
 
                         destroy() {

--- a/src/webview/mermaid-plugin.ts
+++ b/src/webview/mermaid-plugin.ts
@@ -423,7 +423,7 @@ function buildDecorations(doc: any, activeMermaidPos: number): DecorationSet {
                     if (copyBtn.isConnected) flashCopiedState(copyBtn);
                 } catch (err) {
                     reportCopyError(
-                        `Copy mermaid thất bại: ${
+                        `Failed to copy mermaid diagram: ${
                             err instanceof Error ? err.message : String(err)
                         }`,
                     );

--- a/src/webview/mermaid-plugin.ts
+++ b/src/webview/mermaid-plugin.ts
@@ -15,12 +15,22 @@ import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import mermaid from "mermaid";
+import elkLayouts from "@mermaid-js/layout-elk";
 import { openMermaidLightbox } from "./image-lightbox-plugin";
 import {
     copyPngBlobToClipboard,
     reportCopyError,
     svgToPngBlob,
 } from "./svg-to-png";
+
+// Register ELK layout engine for better subgraph/edge routing
+let elkAvailable = false;
+try {
+    mermaid.registerLayoutLoaders(elkLayouts);
+    elkAvailable = true;
+} catch {
+    console.warn("ELK layout registration failed, falling back to dagre");
+}
 
 const EXPAND_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>`;
 const COPY_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
@@ -35,12 +45,23 @@ let mermaidInitialized = false;
 let renderCounter = 0;
 let mermaidBlockCount = 0;
 
+/** Shared mermaid config (layout tuning for complex diagrams). */
+const MERMAID_FLOWCHART_CFG = {
+    nodeSpacing: 80,
+    rankSpacing: 70,
+    subGraphTitleMargin: { top: 10, bottom: 6 },
+    diagramPadding: 16,
+    wrappingWidth: 300,
+    padding: 20,
+};
+
 function ensureMermaidInit(isDark: boolean): void {
     mermaid.initialize({
         startOnLoad: false,
+        layout: elkAvailable ? "elk" : "dagre",
         theme: isDark ? "dark" : "default",
-        securityLevel: "strict",
-        fontFamily: "inherit",
+        securityLevel: "loose",
+        flowchart: MERMAID_FLOWCHART_CFG,
     });
     mermaidInitialized = true;
 }
@@ -51,9 +72,10 @@ function ensureMermaidInit(isDark: boolean): void {
 export function updateMermaidTheme(isDark: boolean): void {
     mermaid.initialize({
         startOnLoad: false,
+        layout: elkAvailable ? "elk" : "dagre",
         theme: isDark ? "dark" : "default",
-        securityLevel: "strict",
-        fontFamily: "inherit",
+        securityLevel: "loose",
+        flowchart: MERMAID_FLOWCHART_CFG,
     });
     // Re-render all existing previews
     document.querySelectorAll<HTMLElement>(".mermaid-preview").forEach((el) => {
@@ -115,7 +137,14 @@ async function renderMermaid(preview: HTMLElement, code: string): Promise<void> 
 
     const id = `mermaid-render-${++renderCounter}`;
     try {
-        const { svg } = await mermaid.render(id, code);
+        // Mermaid v11 no longer auto-converts literal \n inside labels.
+        // Replace \n with <br/> inside any bracket group ([...], (...), {...})
+        // regardless of quote style. Covers plain labels like A[Line1\nLine2].
+        const processed = code.replace(
+            /(\[[^\]]*\]|\([^)]*\)|\{[^}]*\})/g,
+            (match) => match.replace(/\\n/g, "<br/>"),
+        );
+        const { svg } = await mermaid.render(id, processed);
         if (renderCache.size >= MAX_RENDER_CACHE) {
             const oldest = renderCache.keys().next().value;
             if (oldest !== undefined) renderCache.delete(oldest);

--- a/src/webview/svg-to-png.ts
+++ b/src/webview/svg-to-png.ts
@@ -12,11 +12,22 @@ export async function svgToPngBlob(
     svgString: string,
     scale: number = 2,
 ): Promise<Blob> {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(svgString, "image/svg+xml");
-    const svg = doc.documentElement as unknown as SVGSVGElement;
+    // Mermaid with securityLevel:"loose" emits foreignObject containing HTML
+    // (e.g. unclosed <br>, <div>) which breaks strict XML parsing.
+    // Try XML first; fall back to HTML parsing if it fails.
+    let svg: SVGSVGElement | null = null;
 
-    if (!svg || svg.tagName.toLowerCase() !== "svg") {
+    const xmlDoc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+    const parseError = xmlDoc.querySelector("parsererror");
+    if (!parseError && xmlDoc.documentElement.tagName.toLowerCase() === "svg") {
+        svg = xmlDoc.documentElement as unknown as SVGSVGElement;
+    } else {
+        // Fallback: parse as HTML and extract the SVG element
+        const htmlDoc = new DOMParser().parseFromString(svgString, "text/html");
+        svg = htmlDoc.querySelector("svg") as unknown as SVGSVGElement | null;
+    }
+
+    if (!svg) {
         throw new Error("Invalid SVG markup");
     }
 

--- a/src/webview/svg-to-png.ts
+++ b/src/webview/svg-to-png.ts
@@ -31,9 +31,13 @@ export async function svgToPngBlob(
         throw new Error("Invalid SVG markup");
     }
 
-    const { width, height } = resolveSvgSize(svg);
+    let { width, height } = resolveSvgSize(svg);
     if (width <= 0 || height <= 0) {
-        throw new Error("SVG has zero dimensions");
+        // Fallback for SVGs without width/height/viewBox so the mermaid block
+        // still produces a copy/export image instead of failing silently.
+        console.warn("[svgToPng] SVG dimensions missing, using fallback 800x600");
+        width = 800;
+        height = 600;
     }
 
     // Ensure explicit width/height so <img> can rasterize; lightbox strips these.

--- a/src/webview/svg-to-png.ts
+++ b/src/webview/svg-to-png.ts
@@ -8,9 +8,20 @@
 const LOAD_IMAGE_TIMEOUT_MS = 5000;
 const TO_BLOB_TIMEOUT_MS = 5000;
 
+/**
+ * Convert SVG markup to a PNG Blob.
+ *
+ * @param svgString  SVG markup.
+ * @param scale      Pixel scale multiplier (2 = retina).
+ * @param background CSS color for the canvas behind the SVG. Defaults to
+ *                   white so exported/copied mermaid diagrams are readable
+ *                   on any target (Word, Slack, PDF, email). Pass `null`
+ *                   to keep the canvas transparent.
+ */
 export async function svgToPngBlob(
     svgString: string,
     scale: number = 2,
+    background: string | null = "#ffffff",
 ): Promise<Blob> {
     // Mermaid with securityLevel:"loose" emits foreignObject containing HTML
     // (e.g. unclosed <br>, <div>) which breaks strict XML parsing.
@@ -69,6 +80,10 @@ export async function svgToPngBlob(
     canvas.height = Math.max(1, Math.round(height * scale));
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("Canvas 2D context unavailable");
+    if (background) {
+        ctx.fillStyle = background;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     return await new Promise<Blob>((resolve, reject) => {
         const timeoutId = window.setTimeout(

--- a/src/webview/svg-to-png.ts
+++ b/src/webview/svg-to-png.ts
@@ -17,14 +17,19 @@ export async function svgToPngBlob(
     // Try XML first; fall back to HTML parsing if it fails.
     let svg: SVGSVGElement | null = null;
 
-    const xmlDoc = new DOMParser().parseFromString(svgString, "image/svg+xml");
-    const parseError = xmlDoc.querySelector("parsererror");
-    if (!parseError && xmlDoc.documentElement.tagName.toLowerCase() === "svg") {
-        svg = xmlDoc.documentElement as unknown as SVGSVGElement;
-    } else {
-        // Fallback: parse as HTML and extract the SVG element
-        const htmlDoc = new DOMParser().parseFromString(svgString, "text/html");
-        svg = htmlDoc.querySelector("svg") as unknown as SVGSVGElement | null;
+    try {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(svgString, "image/svg+xml");
+        const parseError = xmlDoc.querySelector("parsererror");
+        if (!parseError && xmlDoc.documentElement.tagName.toLowerCase() === "svg") {
+            svg = xmlDoc.documentElement as unknown as SVGSVGElement;
+        } else {
+            // Fallback: parse as HTML and extract the SVG element
+            const htmlDoc = parser.parseFromString(svgString, "text/html");
+            svg = htmlDoc.querySelector("svg") as unknown as SVGSVGElement | null;
+        }
+    } catch (err) {
+        throw new Error(`Invalid SVG markup: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     if (!svg) {
@@ -47,7 +52,12 @@ export async function svgToPngBlob(
         svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
     }
 
-    const serialized = new XMLSerializer().serializeToString(svg);
+    let serialized: string;
+    try {
+        serialized = new XMLSerializer().serializeToString(svg);
+    } catch (err) {
+        throw new Error(`Failed to serialize SVG: ${err instanceof Error ? err.message : String(err)}`);
+    }
     // data: URL stays same-origin with the document so the resulting canvas
     // is not tainted (blob: URLs inside the VS Code webview sandbox can cross
     // the origin boundary and block canvas.toBlob export).


### PR DESCRIPTION
## Summary

Release version **2.8.6** with two major changes: rewritten PDF export pipeline using headless Chromium (`puppeteer-core`) for WYSIWYG quality, and unified DOCX/PDF export pipeline through MDAST.

### Added

- **Export to DOCX** via `mdast2docx` + plugins (`@m2d/html`, `@m2d/image`, `@m2d/table`, `@m2d/list`). Font inherited from editor.
- **Export to PDF** using headless Chromium (`puppeteer-core`). Requires Chrome/Edge/Chromium/Brave already installed.
- **Setting `tuiMarkdown.chromiumPath`** to manually specify the Chromium binary path.

### Changed

- **PDF export rewritten with `puppeteer-core`**: Removed `pdfmake` + custom markdown parser (339 lines) + bundled Roboto. New pipeline: MDAST → HTML (`remark-rehype` + `rehype-highlight` + `rehype-stringify`) → Chromium `page.pdf()`. Bundle ~2.5MB tree-shaken, total VSIX ~5.4MB.
- **Removed MDAST→markdown bridge for PDF**: Both `exportToPdf` and `exportToDocx` receive MDAST directly, eliminating parse/serialize drift. Removed `mdastToMarkdown` + `remark-stringify`.
- **Mermaid `securityLevel: \"loose\"`**: Required for ELK + `foreignObject` HTML labels. PDF export uses `setJavaScriptEnabled(false)` to prevent escalation.

### Fixed

- PDF render relative images → inline base64 instead of silent 404.
- Frontmatter uses `remark-frontmatter` instead of manual regex.
- Mermaid hash CRLF/LF mismatch → normalize line endings before hashing.
- DOCX fetch remote has 30s timeout + 10MB limit. Failed images → placeholder 1x1 PNG.
- DOCX filename containing literal `%` → wrapped with try/catch `decodeURIComponent`.
- Export button race duplicate → `exportInProgress` flag + `exportDone` message.
- Empty document → warning instead of generating empty file.
- PDF font-family CSS sanitized via whitelist `[A-Za-z0-9 _-]`.
- Chromium sandbox `--no-sandbox` only passed on Linux + root.
- PDF strips `<script>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<base>`, `<meta http-equiv>` before feeding to Chromium.
- `waitUntil: \"networkidle0\"` waits for all images to load.
- `rehype-highlight` `detect: false` reduces CPU usage.
- Reveal file after export uses `revealFileInOS` cross-platform.
- Chromium discovery checks `X_OK` + strips extra quotes around setting path.
- `onDidChangeConfiguration` invalidates Chromium cache without requiring reload.
- Puppeteer launch error wrapped with friendly message including setting hint.
- `svgToPngBlob` fallback 800×600 + warn when SVG has zero dimensions.

## Test plan

- [ ] Build extension: `npm run build` succeeds, VSIX ~5.4MB.
- [ ] `npm run lint` has no TypeScript errors.
- [ ] Install VSIX in clean VS Code → open a `.md` file.
- [ ] Export DOCX: heading, list, table, code block, local image, remote image, mermaid render correctly.
- [ ] Export PDF (macOS, Chrome installed): WYSIWYG matches preview, syntax-highlighted code, GitHub table, mermaid base64, relative image paths inlined.
- [ ] Export PDF when no Chromium installed → dialog "Chrome, Edge or Chromium must be installed..." with setting hint.
- [ ] Export PDF with `tuiMarkdown.chromiumPath` pointing to Edge/Brave manually → works correctly.
- [ ] Click Export twice in quick succession → second request rejected, dialog "Export in progress, please wait".
- [ ] Document with only frontmatter → warning "Document is empty".
- [ ] CRLF file containing mermaid → exports PNG correctly (no hash mismatch).
- [ ] DOCX with remote image timeout / 404 → placeholder instead of crash.
- [ ] Copy mermaid as PNG (regression from 2.8.5) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)