### PR TITLE
Release v2.8.8: Lightbox touch pan + tap-outside-to-close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.8] - 2026-05-05
+
+### Fixed
+
+- **Lightbox touch gestures**: Two-finger drag now pans the image (when zoomed in) instead of triggering browser's default pinch-to-zoom. Disabled native touch gestures on lightbox overlay via `touch-action: none`.
+- **Lightbox tap-outside-to-close**: Tapping anywhere outside the image/SVG and controls now closes the lightbox. Works for both mouse click and touch tap.
+
 ## [2.8.6] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,8 +366,9 @@ Uses `@tiptap/core` with `@tiptap/markdown` (Beta, MarkedJS-based parser) for ma
 * Shared fullscreen overlay for both images and mermaid diagrams
 * Dark backdrop, zoom (0.5x–4x), pan by dragging when `scale > 1`
 * Zoom via buttons (+/−), mouse wheel, or keyboard (`+`/`-` step, `0` reset, `Esc` close)
+* Touch: 2-finger drag pans image (when zoomed in); `touch-action: none` on overlay disables browser default pinch-to-zoom
 * Caption from image alt text or explicit string
-* Close via Escape, backdrop click, or close button
+* Close via Escape, click outside image/controls, or close button (overlay-level click handler checks target)
 * Internal state `currentTarget: HTMLElement` switches between `#lightbox-image` and `#lightbox-svg` wrapper; `applyTransform()` writes to whichever is active
 * Exported API:
   * `openLightbox(src, alt)` — image path → `<img>`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -3066,6 +3066,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             justify-content: center;
             flex-direction: column;
             gap: 12px;
+            touch-action: none;
           }
           #lightbox-overlay.active { display: flex; }
           .lightbox-backdrop {

--- a/src/webview/image-lightbox-plugin.ts
+++ b/src/webview/image-lightbox-plugin.ts
@@ -10,6 +10,12 @@ let dragStartTX = 0;
 let dragStartTY = 0;
 let currentTarget: HTMLElement | null = null;
 
+let isTouchPanning = false;
+let touchStartMidX = 0;
+let touchStartMidY = 0;
+let touchStartTX = 0;
+let touchStartTY = 0;
+
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 4;
 const SCALE_STEP = 0.25;
@@ -67,6 +73,7 @@ function resetState() {
   translateX = 0;
   translateY = 0;
   isDragging = false;
+  isTouchPanning = false;
   if (currentTarget) {
     currentTarget.style.transform = '';
     currentTarget.classList.remove('grabbable', 'grabbing');
@@ -154,10 +161,18 @@ let initialized = false;
 export function initLightbox(): void {
   if (initialized) return;
   initialized = true;
-  const { close, backdrop, zoomIn, zoomOut, content, copy } = getElements();
+  const { close, zoomIn, zoomOut, content, copy } = getElements();
 
   close?.addEventListener('click', closeLightbox);
-  backdrop?.addEventListener('click', closeLightbox);
+
+  const controls = document.querySelector('.lightbox-controls');
+  document.getElementById('lightbox-overlay')?.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (target === currentTarget) return;
+    if (currentTarget?.contains(target)) return;
+    if (controls?.contains(target)) return;
+    closeLightbox();
+  });
   zoomIn?.addEventListener('click', () => setScale(scale + SCALE_STEP));
   zoomOut?.addEventListener('click', () => setScale(scale - SCALE_STEP));
   copy?.addEventListener('click', (e) => {
@@ -211,4 +226,36 @@ export function initLightbox(): void {
     isDragging = false;
     currentTarget?.classList.remove('grabbing');
   });
+
+  const overlay = document.getElementById('lightbox-overlay');
+  overlay?.addEventListener('touchstart', (e) => {
+    if (!isActive() || !currentTarget) return;
+    if (e.touches.length === 2 && scale > 1) {
+      e.preventDefault();
+      isTouchPanning = true;
+      touchStartMidX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+      touchStartMidY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+      touchStartTX = translateX;
+      touchStartTY = translateY;
+      currentTarget.classList.add('grabbing');
+    }
+  }, { passive: false });
+
+  overlay?.addEventListener('touchmove', (e) => {
+    if (!isTouchPanning || !currentTarget || e.touches.length < 2) return;
+    e.preventDefault();
+    const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+    const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+    translateX = touchStartTX + (midX - touchStartMidX);
+    translateY = touchStartTY + (midY - touchStartMidY);
+    applyTransform();
+  }, { passive: false });
+
+  overlay?.addEventListener('touchend', (e) => {
+    if (!isTouchPanning) return;
+    if (e.touches.length < 2) {
+      isTouchPanning = false;
+      currentTarget?.classList.remove('grabbing');
+    }
+  }, { passive: true });
 }


### PR DESCRIPTION
## Summary
- Two-finger drag in lightbox now pans image (when zoomed in) instead of browser default pinch-to-zoom
- Tapping/clicking anywhere outside image and controls closes lightbox
- Version bumped to 2.8.8

## Changes
- `src/webview/image-lightbox-plugin.ts`: Touch event handlers (touchstart/move/end), overlay click-to-close handler
- `src/markdownEditorProvider.ts`: `touch-action: none` CSS on lightbox overlay
- `CHANGELOG.md`: v2.8.8 entry
- `CLAUDE.md`: Updated Lightbox section with touch + close behavior

## Test plan
- [ ] Open mermaid diagram in lightbox, zoom in via buttons, 2-finger drag should pan (not zoom)
- [ ] 2-finger drag at 100% scale should NOT pan (only when zoomed in)
- [ ] Tap/click outside image area closes lightbox
- [ ] Zoom buttons, keyboard shortcuts, mouse wheel still work
- [ ] Close button and Escape still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)