### PR TITLE
Release v2.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to "TUI Markdown Editor" extension.
 
+## [2.8.9] - 2026-05-05
+
+### Fixed
+
+- **Search scroll to match (#52)**: Clicking "Search Down/Up" buttons or pressing Enter in search bar now scrolls the matched keyword to the center of the viewport. Previously, matches were found and highlighted but the page didn't scroll because ProseMirror's `scrollToSelection` bails when DOM focus is outside the editor.
+
 ## [2.8.8] - 2026-05-05
 
 ### Fixed

--- a/_bmad-output/implementation-artifacts/spec-gh-52-search-scroll-to-match.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-52-search-scroll-to-match.md
@@ -1,0 +1,17 @@
+---
+title: 'Fix search next/prev not scrolling to match'
+type: 'bugfix'
+created: '2026-05-05'
+status: 'done'
+route: 'one-shot'
+---
+
+## Intent
+
+**Problem:** Clicking "Search Down/Up" buttons (or pressing Enter in search bar) finds the next match but doesn't scroll the page to its position. Root cause: ProseMirror's `scrollToSelection()` bails when DOM focus is outside the editor (focus stays on search bar button/input).
+
+**Approach:** After `findNext`/`findPrev` succeeds, manually compute match coordinates via `coordsAtPos()` and scroll `#editor-container` so the match lands at vertical center of the viewport.
+
+## Suggested Review Order
+
+1. [search-plugin.ts:48-78](src/webview/search-plugin.ts) — `searchNext`/`searchPrev` now check return value + call `scrollSearchMatchIntoView`; new helper scrolls container to center match vertically

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tui-milkdown-vscode",
   "displayName": "TUI Markdown Editor",
   "description": "A beautiful WYSIWYG Markdown editor powered by Tiptap. Edit markdown files with rich text experience and theme selection.",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "publisher": "tuanhv",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/webview/search-plugin.ts
+++ b/src/webview/search-plugin.ts
@@ -47,13 +47,35 @@ export function clearSearch(editor: Editor): void {
 /** Navigate to the next match (ProseMirror command) */
 export function searchNext(editor: Editor): void {
   const { state, dispatch } = editor.view;
-  findNext(state, dispatch);
+  if (findNext(state, dispatch)) {
+    scrollSearchMatchIntoView(editor);
+  }
 }
 
 /** Navigate to the previous match (ProseMirror command) */
 export function searchPrev(editor: Editor): void {
   const { state, dispatch } = editor.view;
-  findPrev(state, dispatch);
+  if (findPrev(state, dispatch)) {
+    scrollSearchMatchIntoView(editor);
+  }
+}
+
+function scrollSearchMatchIntoView(editor: Editor): void {
+  requestAnimationFrame(() => {
+    try {
+      const { head } = editor.view.state.selection;
+      const coords = editor.view.coordsAtPos(head);
+      const container = editor.view.dom.closest("#editor-container") ??
+        document.getElementById("editor-container");
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const centerY = rect.top + rect.height / 2;
+      const offset = coords.top - centerY;
+      if (Math.abs(offset) > 10) {
+        container.scrollTop += offset;
+      }
+    } catch { /* position may be invalid during concurrent edits */ }
+  });
 }
 
 /** Get current match count and active match index */


### PR DESCRIPTION
## Summary

- **Fix search scroll to match (#52)**: Clicking Search Next/Prev buttons or Enter in search bar now scrolls the matched keyword to the center of viewport. Root cause: ProseMirror's `scrollToSelection` bails when DOM focus is outside the editor.
- Version bump to 2.8.9, changelog updated.

## Changes

- `src/webview/search-plugin.ts`: Added `scrollSearchMatchIntoView()` helper — uses `coordsAtPos()` + manual `container.scrollTop` adjustment to center match vertically. `findNext`/`findPrev` return value checked before scrolling.

## Test plan

- [ ] Open a long markdown file in TUI Markdown Editor
- [ ] Press Cmd+F, type a keyword that appears multiple times
- [ ] Click Search Down button — page should scroll to match at center of viewport
- [ ] Click Search Up button — same center-scroll behavior
- [ ] Press Enter/Shift+Enter in search input — same behavior
- [ ] Search for non-existent term — no scroll, "0" match count shown
- [ ] Test with CSS zoom at 150% — scroll position still correct

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)