### PR TITLE
feat: implicit frontmatter + editor title bar toggle

### DIFF
--- a/docs/superpowers/specs/2026-05-21-implicit-frontmatter-design.md
+++ b/docs/superpowers/specs/2026-05-21-implicit-frontmatter-design.md
@@ -1,0 +1,127 @@
+# Implicit Frontmatter Support
+
+## Problem
+
+Editor chỉ nhận frontmatter chuẩn (`---\n...\n---`). File dùng implicit format (YAML trực tiếp ở đầu file, kết thúc bằng `---`) bị render thành setext H2 heading thay vì parse vào metadata panel.
+
+## Goal
+
+Hỗ trợ cả hai format frontmatter:
+
+**Standard** (hiện tại đã hoạt động):
+```
+---
+type: concept
+title: Example
+tags: [a, b]
+---
+
+# Content
+```
+
+**Implicit** (cần thêm):
+```
+type: concept
+title: Example
+tags: [a, b]
+---
+
+# Content
+```
+
+Giữ format gốc khi save. File mở implicit thì save implicit. File mở standard thì save standard.
+
+## Design
+
+### 1. Shared utility: `src/utils/frontmatter-parser.ts` (file mới)
+
+Chứa logic parse/reconstruct, import được từ cả webview bundle lẫn extension bundle.
+
+**Return type mới**:
+
+```typescript
+interface ParseResult {
+  frontmatter: string | null;
+  body: string;
+  isValid: boolean;
+  error?: string;
+  format: 'standard' | 'implicit' | 'none';
+}
+```
+
+**Detection flow trong `parseContent()`**:
+
+1. Thử regex chuẩn: `^---[ \t]*\n([\s\S]*?)\n---[ \t]*(?:\n|$)` → `format = 'standard'`
+2. Nếu không match → implicit detection:
+   - Tìm dòng `---` đầu tiên (regex: `\n---[ \t]*(?:\n|$)`)
+   - Lấy nội dung phía trước
+   - `yaml.load()` → kiểm tra kết quả
+   - Điều kiện accept: plain object, ≥2 keys, ≥1 key thuộc `KNOWN_KEYS`
+   - Match → `format = 'implicit'`
+3. Không match → `format = 'none'`, `frontmatter = null`
+
+**Known keys** (chống false positive):
+
+```typescript
+const KNOWN_KEYS = new Set([
+  'title', 'type', 'date', 'created', 'updated',
+  'tags', 'categories', 'author', 'draft', 'slug',
+  'description', 'related', 'sources', 'aliases',
+  'layout', 'permalink', 'published'
+]);
+```
+
+**`reconstructContent()` thêm tham số format**:
+
+```typescript
+function reconstructContent(
+  frontmatter: string | null,
+  body: unknown,
+  format: 'standard' | 'implicit' | 'none'
+): string
+```
+
+| format | frontmatter có data | Output |
+|--------|-------------------|--------|
+| `standard` | có | `---\nyaml\n---\n\nbody` |
+| `implicit` | có | `yaml\n---\n\nbody` |
+| `none` | có | `---\nyaml\n---\n\nbody` |
+| bất kỳ | null/rỗng | chỉ `body` |
+
+### 2. `src/webview/frontmatter.ts`
+
+Giữ lại phần UI: `validateYaml()`, `updateMetadataPanel()`. Import logic parse/reconstruct từ shared utility.
+
+### 3. `src/webview/main.ts`
+
+- Thêm biến `currentFormat: 'standard' | 'implicit' | 'none'`
+- Khi nhận content → `parseContent()` → lưu `format` vào `currentFormat`
+- Khi save → `reconstructContent(frontmatter, body, currentFormat)`
+
+### 4. `src/markdownEditorProvider.ts`
+
+Export DOCX/PDF: import `parseContent()` từ shared utility. Tách frontmatter trước khi đưa vào MDAST pipeline. Giải quyết vấn đề `remark-frontmatter` không hiểu implicit format.
+
+### 5. Nút "Add Metadata"
+
+Giữ nguyên. Metadata mới tạo dùng format `standard`.
+
+## Edge Cases
+
+| Case | Xử lý |
+|------|--------|
+| `Note: text\n---` (1 key) | Reject, coi là setext heading |
+| `First: a\nSecond: b\n---` (2 keys, 0 known) | Reject, coi là content |
+| File chỉ có metadata, không body | `body = ""`, giữ format |
+| Nested YAML objects | js-yaml hỗ trợ sẵn |
+| `---` giữa body (HR) | Chỉ xét `---` đầu tiên |
+| File rỗng | `format = 'none'` |
+| YAML invalid ở implicit format | Reject, toàn bộ là body |
+
+## Không thay đổi
+
+- Metadata panel UI (textarea raw YAML)
+- Nút "Add Metadata" behavior
+- Debounce 300ms
+- Validation logic
+- CSP, nonce, state persistence


### PR DESCRIPTION
## Summary

- **Implicit Frontmatter**: Hỗ trợ frontmatter không có `---` mở đầu. YAML key-value ở đầu file kết thúc bằng `---` được phát hiện và parse vào metadata panel. Shared parser (`src/utils/frontmatter-parser.ts`) dùng chung cho webview và extension (DOCX/PDF export).
- **Editor Title Bar Toggle**: Thêm icon trên VSCode editor title bar để switch giữa WYSIWYG và source view. Icon `$(code)` khi đang WYSIWYG, `$(eye)` khi đang text editor. Hỗ trợ `.md` và `.markdown`.

## Test plan

- [ ] Mở file `.md` có frontmatter implicit (YAML keys ở đầu, kết thúc bằng `---`), verify metadata panel hiển thị đúng
- [ ] Mở file `.md` có frontmatter standard (`---` ... `---`), verify vẫn hoạt động bình thường
- [ ] Verify icon `$(code)` hiện trên editor title bar khi đang WYSIWYG
- [ ] Click icon → chuyển sang text editor, verify icon đổi thành `$(eye)`
- [ ] Click `$(eye)` → quay lại WYSIWYG
- [ ] Mở file `.ts`/`.json`, verify không có icon toggle
- [ ] Export DOCX/PDF với file có implicit frontmatter, verify frontmatter bị strip đúng

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File mention (`@`) autocomplete for workspace files, inserted as Markdown links
  * Obsidian-style wiki links (`[[...]]`) with click-to-navigate support
  * Editor title bar toggle to switch between WYSIWYG and source views
  * Implicit frontmatter detection and parsing support

* **Improvements**
  * Enhanced PDF export pipeline with improved image and frontmatter handling
  * Better export robustness and performance optimizations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoangvantuan/tui-milkdown-vscode/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->